### PR TITLE
feat(camunda-cloud): disable user task support

### DIFF
--- a/lib/camunda-cloud/Modeler.js
+++ b/lib/camunda-cloud/Modeler.js
@@ -18,6 +18,8 @@ import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json';
 
 import zeebeModdleExtension from 'zeebe-bpmn-moddle/lib';
 
+import disableUserTasksModule from './features/disable-user-tasks';
+
 
 /**
  *
@@ -32,6 +34,17 @@ export default function Modeler(options = {}) {
       ...options.moddleExtensions
     }
   };
+
+  /**
+   * @pinussilvestrus: Disable Zeebe User Task support until the Engine is supporting it
+   * Cf. https://github.com/camunda/camunda-modeler/issues/2140
+   */
+  if (!options.enableZeebeUserTasks) {
+    this._modules = [
+      ...this._modules,
+      disableUserTasksModule
+    ];
+  }
 
   BaseModeler.call(this, options);
 }

--- a/lib/camunda-cloud/features/disable-user-tasks/DisableUserTasks.js
+++ b/lib/camunda-cloud/features/disable-user-tasks/DisableUserTasks.js
@@ -1,0 +1,35 @@
+import {
+  filter
+} from 'min-dash';
+
+const REPLACE_WITH_USER_TASKS = 'replace-with-user-task';
+
+const FORMS_TAB = 'forms';
+
+const LOW_PRIORITY = 500;
+
+export default class DisableUserTasks {
+  constructor(popupMenu, propertiesPanel) {
+    popupMenu.registerProvider('bpmn-replace', LOW_PRIORITY, this);
+    propertiesPanel.registerProvider(LOW_PRIORITY, this);
+  }
+
+  // (1) disable replace option
+  getPopupMenuEntries(element) {
+    return function(entries) {
+      delete entries[REPLACE_WITH_USER_TASKS];
+      return entries;
+    };
+  }
+
+  // (2) disable properties provider entries
+  getTabs(element) {
+    return function(entries) {
+      return filter(entries, function(tab) {
+        return tab.id !== FORMS_TAB;
+      });
+    };
+  }
+}
+
+DisableUserTasks.$inject = [ 'popupMenu', 'propertiesPanel' ];

--- a/lib/camunda-cloud/features/disable-user-tasks/index.js
+++ b/lib/camunda-cloud/features/disable-user-tasks/index.js
@@ -1,0 +1,9 @@
+import DisableUserTasks from './DisableUserTasks';
+
+export default {
+  __init__: [ 'disableUserTasks' ],
+  disableUserTasks: [ 'type', DisableUserTasks ],
+
+  // disable user task modeling behaviors
+  formDefinitionBehavior: [ 'value', null ]
+};

--- a/test/camunda-cloud/features/disable-user-tasks/DisableUserTasksSpec.js
+++ b/test/camunda-cloud/features/disable-user-tasks/DisableUserTasksSpec.js
@@ -1,0 +1,139 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import Modeler from 'lib/camunda-cloud/Modeler';
+
+import {
+  getBpmnJS,
+  clearBpmnJS,
+  setBpmnJS
+} from 'test/TestHelper';
+
+import simpleXML from 'test/fixtures/simple.bpmn';
+
+
+describe('camunda-cloud/features - DisableUserTasks', function() {
+
+  let modelerContainer,
+      propertiesContainer;
+
+  function createModeler(xml, options = {}) {
+
+    clearBpmnJS();
+
+    const modeler = new Modeler({
+      container: modelerContainer,
+      keyboard: {
+        bindTo: document
+      },
+      propertiesPanel: {
+        parent: propertiesContainer
+      },
+      ...options
+    });
+
+    setBpmnJS(modeler);
+
+    return modeler.importXML(xml).then(function(result) {
+      return { error: null, warnings: result.warnings, modeler: modeler };
+    }).catch(function(err) {
+      return { error: err, warnings: err.warnings, modeler: modeler };
+    });
+  }
+
+  beforeEach(function() {
+    modelerContainer = document.createElement('div');
+    propertiesContainer = document.createElement('div');
+
+    const container = TestContainer.get(this);
+
+    container.appendChild(propertiesContainer);
+    container.appendChild(modelerContainer);
+  });
+
+
+  /**
+   * @pinussilvestrus: user tasks support is currently disabled
+   * Cf. https://github.com/camunda/camunda-modeler/issues/2140
+   */
+  it('should disable support per default', function() {
+    return createModeler(simpleXML).then(function(result) {
+      const modeler = result.modeler;
+
+      const elementRegistry = modeler.get('elementRegistry'),
+            popupMenu = modeler.get('popupMenu'),
+            bpmnjs = modeler.get('bpmnjs'),
+            selection = modeler.get('selection');
+
+      // given
+      const element = elementRegistry.get('Activity_08bosyf');
+
+      // when
+      selection.select(element);
+
+      openPopup(element);
+
+      // then
+      expect(queryEntry(popupMenu, 'replace-with-user-task')).not.to.exist;
+
+      expect(findTab(propertiesContainer, 'forms')).not.to.exist;
+
+      expect(bpmnjs.get('formDefinitionBehavior')).not.to.exist;
+    });
+  });
+
+
+  it('should enable support if configured', function() {
+
+    return createModeler(simpleXML, { enableZeebeUserTasks: true }).then(function(result) {
+      const modeler = result.modeler;
+
+      const elementRegistry = modeler.get('elementRegistry'),
+            popupMenu = modeler.get('popupMenu'),
+            bpmnjs = modeler.get('bpmnjs'),
+            selection = modeler.get('selection');
+
+      // given
+      const element = elementRegistry.get('Activity_08bosyf');
+
+      // when
+      selection.select(element);
+
+      openPopup(element);
+
+      // then
+      expect(queryEntry(popupMenu, 'replace-with-user-task')).to.exist;
+
+      expect(findTab(propertiesContainer, 'forms')).to.exist;
+
+      expect(bpmnjs.get('formDefinitionBehavior')).to.exist;
+    });
+  });
+
+});
+
+
+// helper /////////////////////////
+
+function queryEntry(popupMenu, id) {
+  return domQuery('[data-id="' + id + '"]', popupMenu._current.container);
+}
+
+function openPopup(element, offset) {
+  offset = offset || 100;
+
+  getBpmnJS().invoke(function(popupMenu) {
+
+    popupMenu.open(element, 'bpmn-replace', {
+      x: element.x + offset, y: element.y + offset
+    });
+
+  });
+}
+
+function findTab(container, tabName) {
+  return domQuery(`div[data-tab="${tabName}"]`, container);
+}

--- a/test/camunda-cloud/features/palette/PaletteProviderSpec.js
+++ b/test/camunda-cloud/features/palette/PaletteProviderSpec.js
@@ -38,7 +38,7 @@ const testModules = [
   modelingModule
 ];
 
-describe('camunda-cloud/features/modeling - Palette', function() {
+describe('camunda-cloud/features - Palette', function() {
 
   beforeEach(bootstrapCamundaCloudModeler(diagramXML, { modules: testModules }));
 


### PR DESCRIPTION
I decided to solve it via a small extension which disables all part of the user tasks support (replace menu, properties provider, modeling behaviors) to keep the basic modules untouched. Once we achieve support with the May release, we can simply remove this extension.

Note: it can be re-enabled once configured via `enableZeebeUserTasks` flag.

Related to camunda/camunda-modeler#2140