### PR TITLE
chore: add dependabot config to bump on bpmn-js updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers: # Automatically assign reviewer
+      - "bpmn-io/modeling-dev"
+    allow:
+      - dependency-name: "bpmn-js"
+        dependency-type: "all"
+    commit-message:
+      prefix: "chore:"
+    versioning-strategy: "increase"


### PR DESCRIPTION
I thought about adding other dependencies as well, as `bpmn-js-properties-panel` or `camunda-bpmn-moddle` where we had multiple (manual) updates in the past. 

However, it's not supported currently to group these updates into a single PR (https://github.com/dependabot/dependabot-core/issues/1190). Also, the amount of libraries we have to update after a `bpmn-js-properties-panel` or `camunda-bpmn-moddle` release is not as high as for `bpmn-js`, so it's okay for now.