### PR TITLE
Platform implementation behaviors

### DIFF
--- a/lib/camunda-platform/features/modeling/behavior/DeleteErrorEventDefinitionBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/DeleteErrorEventDefinitionBehavior.js
@@ -1,0 +1,90 @@
+import inherits from 'inherits';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+const HIGH_PRIORITY = 5000;
+
+
+/**
+ * Camunda BPMN specific `camunda:errorEventDefinition` behavior.
+ *
+ * When `camunda:type` is set to something different than `external`
+ * on an element, then `camunda:errorEventDefinition` extension elements
+ * shall be removed.
+ */
+export default function DeleteErrorEventDefinitionBehavior(eventBus) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  this.executed([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
+    HIGH_PRIORITY, function(context) {
+      const {
+        element,
+        oldProperties,
+        properties
+      } = context;
+
+      const businessObject = getBusinessObject(element),
+            extensionElements = businessObject.extensionElements;
+
+      // (1) Check whether behavior is suitable
+      if (
+        is(element, 'camunda:ExternalCapable') &&
+        extensionElements &&
+        externalTypeChanged(oldProperties, properties)
+      ) {
+
+        // (2) Delete camunda:ErrorEventDefinition elements and save them for revert
+        context.deletedErrorEventDefinitions = extensionElements.values;
+
+        extensionElements.values = extensionElements.values.filter(
+          element => !is(element, 'camunda:ErrorEventDefinition')
+        );
+      }
+
+    }, true);
+
+  this.reverted([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
+    HIGH_PRIORITY, function({ context }) {
+      const {
+        element,
+        deletedErrorEventDefinitions: oldExtensionElements
+      } = context;
+
+      const businessObject = getBusinessObject(element);
+
+      // Only intercept the revert, if the behavior became active
+      if (oldExtensionElements) {
+        const extensionElements = businessObject.extensionElements;
+
+        extensionElements.values = oldExtensionElements;
+      }
+    });
+}
+
+
+DeleteErrorEventDefinitionBehavior.$inject = [
+  'eventBus'
+];
+
+inherits(DeleteErrorEventDefinitionBehavior, CommandInterceptor);
+
+
+// helper //////////////////
+
+function externalTypeChanged(oldProperties, updatesProperties) {
+  const {
+    'camunda:type': oldType
+  } = oldProperties;
+
+  const {
+    'camunda:type': newType
+  } = updatesProperties;
+
+  return oldType === 'external' && newType !== 'external';
+}

--- a/lib/camunda-platform/features/modeling/behavior/UpdateResultVariableBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateResultVariableBehavior.js
@@ -1,0 +1,56 @@
+import inherits from 'inherits';
+
+import {
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  has
+} from 'min-dash';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+const HIGH_PRIORITY = 5000;
+
+
+/**
+ * Camunda BPMN specific `camunda:resultVariable` behavior.
+ *
+ * When `camunda:resultVariable` is removed from a service task like element
+ * `camunda:mapDecisionResult` for the element will be cleaned up.
+ */
+export default function UpdateResultVariableBehavior(eventBus) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  this.preExecute([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
+    HIGH_PRIORITY, function(context) {
+      const {
+        element,
+        properties
+      } = context;
+
+      if (
+        is(element, 'camunda:DmnCapable') &&
+        has(properties, 'camunda:resultVariable') &&
+        isEmpty(properties['camunda:resultVariable'])
+      ) {
+        properties['camunda:mapDecisionResult'] = null;
+      }
+    }, true);
+}
+
+
+UpdateResultVariableBehavior.$inject = [
+  'eventBus'
+];
+
+inherits(UpdateResultVariableBehavior, CommandInterceptor);
+
+
+// helper //////////////////
+
+function isEmpty(value) {
+  return value == undefined || value === '';
+}
+

--- a/lib/camunda-platform/features/modeling/behavior/index.js
+++ b/lib/camunda-platform/features/modeling/behavior/index.js
@@ -1,13 +1,16 @@
+import DeleteErrorEventDefinitionBehavior from './DeleteErrorEventDefinitionBehavior';
 import DeleteRetryTimeCycleBehavior from './DeleteRetryTimeCycleBehavior';
 import UpdateCamundaExclusiveBehavior from './UpdateCamundaExclusiveBehavior';
 import UpdateResultVariableBehavior from './UpdateResultVariableBehavior';
 
 export default {
   __init__: [
+    'deleteErrorEventDefinitionBehavior',
     'deleteRetryTimeCycleBehavior',
     'updateCamundaExclusiveBehavior',
     'updateResultVariableBehavior'
   ],
+  deleteErrorEventDefinitionBehavior: [ 'type', DeleteErrorEventDefinitionBehavior ],
   deleteRetryTimeCycleBehavior: [ 'type', DeleteRetryTimeCycleBehavior ],
   updateCamundaExclusiveBehavior: [ 'type', UpdateCamundaExclusiveBehavior ],
   updateResultVariableBehavior: [ 'type', UpdateResultVariableBehavior ]

--- a/lib/camunda-platform/features/modeling/behavior/index.js
+++ b/lib/camunda-platform/features/modeling/behavior/index.js
@@ -1,12 +1,14 @@
-import UpdateCamundaExclusiveBehavior from './UpdateCamundaExclusiveBehavior';
 import DeleteRetryTimeCycleBehavior from './DeleteRetryTimeCycleBehavior';
-
+import UpdateCamundaExclusiveBehavior from './UpdateCamundaExclusiveBehavior';
+import UpdateResultVariableBehavior from './UpdateResultVariableBehavior';
 
 export default {
   __init__: [
+    'deleteRetryTimeCycleBehavior',
     'updateCamundaExclusiveBehavior',
-    'deleteRetryTimeCycleBehavior'
+    'updateResultVariableBehavior'
   ],
+  deleteRetryTimeCycleBehavior: [ 'type', DeleteRetryTimeCycleBehavior ],
   updateCamundaExclusiveBehavior: [ 'type', UpdateCamundaExclusiveBehavior ],
-  deleteRetryTimeCycleBehavior: [ 'type', DeleteRetryTimeCycleBehavior ]
+  updateResultVariableBehavior: [ 'type', UpdateResultVariableBehavior ]
 };

--- a/test/camunda-platform/features/modeling/DeleteErrorEventDefinitionBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/DeleteErrorEventDefinitionBehaviorSpec.js
@@ -1,0 +1,171 @@
+import {
+  bootstrapCamundaPlatformModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import {
+  is,
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
+
+import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
+import diagramXML from './camunda-error-event-definition-diagram.bpmn';
+
+
+describe('camunda-platform/features/modeling - DeleteErrorEventDefinitionBehavior', function() {
+
+  const testModules = [
+    camundaPlatformModelingModules,
+    coreModule,
+    modelingModule,
+    propertiesPanelCommandHandler
+  ];
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+  beforeEach(bootstrapCamundaPlatformModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+  describe('properties-panel.update-businessobject', function() {
+
+    describe('camunda:type to non-external', function() {
+
+      let shape, context, businessObject;
+
+      beforeEach(inject(function(elementRegistry, commandStack) {
+
+        // given
+        shape = elementRegistry.get('ServiceTask_1');
+        businessObject = getBusinessObject(shape);
+
+        context = {
+          element: shape,
+          businessObject: businessObject,
+          properties: {
+            'camunda:type': 'foo'
+          }
+        };
+
+        // assume
+        expect(getErrorEventDefinitions(businessObject)).to.have.length(3);
+
+        // when
+        commandStack.execute('properties-panel.update-businessobject', context);
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getErrorEventDefinitions(businessObject)).to.be.empty;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getErrorEventDefinitions(businessObject)).to.have.length(3);
+      }));
+
+
+      it('should undo/redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getErrorEventDefinitions(businessObject)).to.be.empty;
+      }));
+
+    });
+
+  });
+
+
+  describe('element.updateProperties', function() {
+
+    describe('camunda:type to non-external', function() {
+
+      let shape, businessObject;
+
+      beforeEach(inject(function(elementRegistry, modeling) {
+
+        // given
+        shape = elementRegistry.get('ServiceTask_1');
+        businessObject = getBusinessObject(shape);
+
+        // assume
+        expect(getErrorEventDefinitions(businessObject)).to.have.length(3);
+
+        // when
+        modeling.updateProperties(shape, {
+          'camunda:type': 'foo'
+        });
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getErrorEventDefinitions(businessObject)).to.be.empty;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getErrorEventDefinitions(businessObject)).to.have.length(3);
+      }));
+
+
+      it('should undo/redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getErrorEventDefinitions(businessObject)).to.be.empty;
+      }));
+
+    });
+
+  });
+
+});
+
+
+// helper ///////////
+
+function getErrorEventDefinitions(businessObject) {
+  return getExtensionElementsList(businessObject, 'camunda:ErrorEventDefinition');
+}
+
+function getExtensionElementsList(businessObject, type = undefined) {
+  const elements = ((businessObject.get('extensionElements') &&
+                  businessObject.get('extensionElements').get('values')) || []);
+
+  return (elements.length && type) ?
+    elements.filter((value) => is(value, type)) :
+    elements;
+}

--- a/test/camunda-platform/features/modeling/UpdateResultVariableBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UpdateResultVariableBehaviorSpec.js
@@ -1,0 +1,154 @@
+import {
+  bootstrapCamundaPlatformModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
+
+import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
+import diagramXML from './camunda-result-variable-diagram.bpmn';
+
+
+describe('camunda-platform/features/modeling - UpdateResultVariableBehavior', function() {
+
+  const testModules = [
+    camundaPlatformModelingModules,
+    coreModule,
+    modelingModule,
+    propertiesPanelCommandHandler
+  ];
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+  beforeEach(bootstrapCamundaPlatformModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+  describe('properties-panel.update-businessobject', function() {
+
+    describe('resultVariable to empty', function() {
+
+      let shape, context, businessObject;
+
+      beforeEach(inject(function(elementRegistry, commandStack) {
+
+        // given
+        shape = elementRegistry.get('BusinessRuleTask_1');
+        businessObject = getBusinessObject(shape);
+
+        context = {
+          element: shape,
+          businessObject: businessObject,
+          properties: {
+            'camunda:resultVariable': ''
+          }
+        };
+
+        // assume
+        expect(businessObject.get('camunda:mapDecisionResult')).to.eql('collectEntries');
+
+        // when
+        commandStack.execute('properties-panel.update-businessobject', context);
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(businessObject.get('camunda:mapDecisionResult')).to.eql('collectEntries');
+      }));
+
+
+      it('should undo/redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
+      }));
+
+    });
+
+  });
+
+
+  describe('element.updateProperties', function() {
+
+    describe('resultVariable to empty', function() {
+
+      let shape, businessObject;
+
+      beforeEach(inject(function(elementRegistry, modeling) {
+
+        // given
+        shape = elementRegistry.get('BusinessRuleTask_1');
+        businessObject = getBusinessObject(shape);
+
+        // assume
+        expect(businessObject.get('camunda:mapDecisionResult')).to.eql('collectEntries');
+
+        // when
+        modeling.updateProperties(shape, {
+          'camunda:resultVariable': ''
+        });
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(businessObject.get('camunda:mapDecisionResult')).to.eql('collectEntries');
+      }));
+
+
+      it('should undo/redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
+      }));
+
+    });
+
+  });
+
+});

--- a/test/camunda-platform/features/modeling/camunda-error-event-definition-diagram.bpmn
+++ b/test/camunda-platform/features/modeling/camunda-error-event-definition-diagram.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0gocifa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0-nightly.20210721" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" camunda:type="external" camunda:topic="topic">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_1" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_2" errorRef="Error_2" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_3" errorRef="Error_3" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="Error_1" />
+  <bpmn:error id="Error_2" name="Error_2" />
+  <bpmn:error id="Error_3" name="Error_3" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_09ir90a_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-platform/features/modeling/camunda-result-variable-diagram.bpmn
+++ b/test/camunda-platform/features/modeling/camunda-result-variable-diagram.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0gocifa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0-nightly.20210721" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_0mfdfzi" isExecutable="true">
+    <bpmn:businessRuleTask id="BusinessRuleTask_1" camunda:resultVariable="var1" camunda:decisionRef="Decision_1" camunda:mapDecisionResult="collectEntries" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0mfdfzi">
+      <bpmndi:BPMNShape id="Activity_1pswekv_di" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Related to bpmn-io/bpmn-properties-panel#41

Ensures we
* clean up error event definitions once service task type got changed to something different then `external`
* clean up `camunda:mapDecisionResult` for empty result variables