### PR TITLE
feat(camunda-platform): set either camunda:formKey or formRef

### DIFF
--- a/lib/camunda-platform/features/modeling/behavior/UserTaskFormsBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UserTaskFormsBehavior.js
@@ -1,0 +1,52 @@
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { isUndefined } from 'min-dash';
+
+
+/**
+ * Camunda BPMN specific user task forms behavior ensuring that only one of the following options is configured:
+ *
+ * 1. embedded, external or Camunda forms using camunda:formKey
+ * 2. Camunda forms using camunda:formRef
+ */
+export default class UserTaskFormsBehavior extends CommandInterceptor {
+  constructor(eventBus) {
+    super(eventBus);
+
+    this.preExecute([
+      'element.updateProperties',
+      'element.updateModdleProperties',
+      'properties-panel.update-businessobject'
+    ], function(context) {
+      const { properties } = context;
+
+      if ('camunda:formKey' in properties) {
+        Object.assign(properties, {
+          'camunda:formRef': undefined,
+          'camunda:formRefBinding': undefined,
+          'camunda:formRefVersion': undefined
+        });
+      } else if ('camunda:formRef' in properties) {
+        Object.assign(properties, {
+          'camunda:formKey': undefined
+        });
+
+        if (isUndefined(properties[ 'camunda:formRef' ])) {
+          Object.assign(properties, {
+            'camunda:formRefBinding': undefined,
+            'camunda:formRefVersion': undefined
+          });
+        }
+      }
+
+      if ('camunda:formRefBinding' in properties && properties[ 'camunda:formRefBinding' ] !== 'version') {
+        Object.assign(properties, {
+          'camunda:formRefVersion': undefined
+        });
+      }
+    }, true);
+  }
+}
+
+
+UserTaskFormsBehavior.$inject = [ 'eventBus' ];

--- a/lib/camunda-platform/features/modeling/behavior/index.js
+++ b/lib/camunda-platform/features/modeling/behavior/index.js
@@ -2,16 +2,19 @@ import DeleteErrorEventDefinitionBehavior from './DeleteErrorEventDefinitionBeha
 import DeleteRetryTimeCycleBehavior from './DeleteRetryTimeCycleBehavior';
 import UpdateCamundaExclusiveBehavior from './UpdateCamundaExclusiveBehavior';
 import UpdateResultVariableBehavior from './UpdateResultVariableBehavior';
+import UserTaskFormsBehavior from './UserTaskFormsBehavior';
 
 export default {
   __init__: [
     'deleteErrorEventDefinitionBehavior',
     'deleteRetryTimeCycleBehavior',
     'updateCamundaExclusiveBehavior',
-    'updateResultVariableBehavior'
+    'updateResultVariableBehavior',
+    'userTaskFormsBehavior'
   ],
   deleteErrorEventDefinitionBehavior: [ 'type', DeleteErrorEventDefinitionBehavior ],
   deleteRetryTimeCycleBehavior: [ 'type', DeleteRetryTimeCycleBehavior ],
   updateCamundaExclusiveBehavior: [ 'type', UpdateCamundaExclusiveBehavior ],
-  updateResultVariableBehavior: [ 'type', UpdateResultVariableBehavior ]
+  updateResultVariableBehavior: [ 'type', UpdateResultVariableBehavior ],
+  userTaskFormsBehavior: [ 'type', UserTaskFormsBehavior ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1815,9 +1815,9 @@
       "dev": true
     },
     "camunda-bpmn-moddle": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-5.1.2.tgz",
-      "integrity": "sha512-gjpY0xBWkM08l0Z5cEtZwQF/RYDyA8sgi1kp/pRA5mLOSQLXoMv2SH14G2t59LtanjLzTh6uwX0Tptlhvq/xiw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-6.0.0.tgz",
+      "integrity": "sha512-Fvssx+GBRRueSeLwUbNb3nNKOHm/xcntZMv4Njv6S7XXpvmwGs4+4BrM90Gba2ltprWnAVe4wnTVhCL67DUazQ==",
       "requires": {
         "min-dash": "^3.5.2"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bpmn-js-executable-fix": "^0.1.3",
     "bpmn-js-properties-panel": "^0.44.0",
     "bpmn-js-signavio-compat": "^1.2.3",
-    "camunda-bpmn-moddle": "^5.1.2",
+    "camunda-bpmn-moddle": "^6.0.0",
     "diagram-js": "^7.3.0",
     "diagram-js-minimap": "^2.0.4",
     "diagram-js-origin": "^1.3.2",

--- a/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
@@ -1,0 +1,270 @@
+import {
+  bootstrapCamundaPlatformModeler,
+  inject
+} from 'test/TestHelper';
+
+import {
+  getBpmnJS
+} from 'bpmn-js/test/helper';
+
+import coreModule from 'bpmn-js/lib/core';
+
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
+
+import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
+import diagramXML from './camunda-user-task-forms-diagram.bpmn';
+
+
+describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function() {
+
+  const testModules = [
+    camundaPlatformModelingModules,
+    coreModule,
+    modelingModule,
+    propertiesPanelCommandHandler
+  ];
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+  beforeEach(bootstrapCamundaPlatformModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+  function updateProperties(element, properties) {
+    getBpmnJS().invoke(function(modeling) {
+      modeling.updateProperties(element, properties);
+    });
+  }
+
+  function updateModdleProperties(element, properties) {
+    getBpmnJS().invoke(function(modeling) {
+      modeling.updateModdleProperties(element, getBusinessObject(element), properties);
+    });
+  }
+
+  function updateBusinessObject(element, properties) {
+    getBpmnJS().invoke(function(commandStack) {
+      commandStack.execute('properties-panel.update-businessobject', {
+        element,
+        businessObject: getBusinessObject(element),
+        properties
+      });
+    });
+  }
+
+  [
+    [ 'element.updateProperties', updateProperties ],
+    [ 'element.updateModdleProperties', updateModdleProperties ],
+    [ 'properties-panel.update-businessobject', updateBusinessObject ],
+  ].forEach(([ command, fn ]) => {
+
+    describe(command, function() {
+
+      [
+        [ 'start event', 'StartEvent' ],
+        [ 'user task', 'UserTask' ]
+      ].forEach(([ type, prefix ]) => {
+
+        describe('setting camunda:formKey', function() {
+
+          describe(type, function() {
+
+            let businessObject;
+
+            beforeEach(inject(function(elementRegistry) {
+
+              // given
+              const element = elementRegistry.get(`${ prefix }_FormRef`);
+
+              businessObject = getBusinessObject(element);
+
+              // when
+              fn(element, { 'camunda:formKey': 'embedded:deployment:FORM_NAME.html' });
+
+              // assume
+              expect(businessObject.get('camunda:formKey')).to.equal('embedded:deployment:FORM_NAME.html');
+            }));
+
+
+            it('should execute', inject(function() {
+
+              // then
+              expect(businessObject.get('camunda:formRef')).to.not.exist;
+              expect(businessObject.get('camunda:formRefBinding')).to.equal('latest');
+              expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
+            }));
+
+
+            it('should undo', inject(function(commandStack) {
+
+              // when
+              commandStack.undo();
+
+              // then
+              expect(businessObject.get('camunda:formRef')).to.eql('invoice.form');
+              expect(businessObject.get('camunda:formRefBinding')).to.eql('version');
+              expect(businessObject.get('camunda:formRefVersion')).to.eql('1');
+            }));
+
+
+            it('should undo/redo', inject(function(commandStack) {
+
+              // when
+              commandStack.undo();
+              commandStack.redo();
+
+              // then
+              expect(businessObject.get('camunda:formRef')).to.not.exist;
+              expect(businessObject.get('camunda:formRefBinding')).to.equal('latest');
+              expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
+            }));
+
+          });
+
+        });
+
+
+        describe('setting camunda:formRef', function() {
+
+          describe(type, function() {
+
+            let businessObject;
+
+            beforeEach(inject(function(elementRegistry) {
+
+              // given
+              const element = elementRegistry.get(`${ prefix }_FormKey`);
+
+              businessObject = getBusinessObject(element);
+
+              // when
+              fn(element, {
+                'camunda:formRef': 'invoice.form',
+                'camunda:formRefBinding': 'version',
+                'camunda:formRefVersion': '1'
+              });
+
+              // assume
+              expect(businessObject.get('camunda:formRef')).to.equal('invoice.form');
+              expect(businessObject.get('camunda:formRefBinding')).to.equal('version');
+              expect(businessObject.get('camunda:formRefVersion')).to.equal('1');
+            }));
+
+
+            it('should execute', inject(function() {
+
+              // then
+              expect(businessObject.get('camunda:formKey')).to.not.exist;
+            }));
+
+
+            it('should undo', inject(function(commandStack) {
+
+              // when
+              commandStack.undo();
+
+              // then
+              expect(businessObject.get('camunda:formKey')).to.eql('embedded:deployment:FORM_NAME.html');
+            }));
+
+
+            it('should undo/redo', inject(function(commandStack) {
+
+              // when
+              commandStack.undo();
+              commandStack.redo();
+
+              // then
+              expect(businessObject.get('camunda:formKey')).to.not.exist;
+            }));
+
+          });
+
+        });
+
+
+        describe('setting camunda:formRefBinding', function() {
+
+          describe(type, function() {
+
+            it('should delete camunda:formRefVersion', inject(function(elementRegistry) {
+
+              // when
+              const element = elementRegistry.get(`${ prefix }_FormRef`);
+
+              const businessObject = getBusinessObject(element);
+
+              // when
+              fn(element, { 'camunda:formRefBinding': 'deployment' });
+
+              // then
+              expect(businessObject.get('camunda:formRef')).to.equal('invoice.form');
+              expect(businessObject.get('camunda:formRefBinding')).to.equal('deployment');
+              expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
+            }));
+
+
+            it('should not delete camunda:formRefVersion', inject(function(elementRegistry) {
+
+              // when
+              const element = elementRegistry.get(`${ prefix }_FormRef`);
+
+              const businessObject = getBusinessObject(element);
+
+              // when
+              fn(element, { 'camunda:formRefBinding': 'version' });
+
+              // then
+              expect(businessObject.get('camunda:formRef')).to.equal('invoice.form');
+              expect(businessObject.get('camunda:formRefBinding')).to.equal('version');
+              expect(businessObject.get('camunda:formRefVersion')).to.equal('1');
+            }));
+
+          });
+
+        });
+
+
+        describe('deleting camunda:formRef', function() {
+
+          describe(type, function() {
+
+            it('should delete camunda:formRefBinding and camunda:formRefVersion', inject(function(elementRegistry) {
+
+              // when
+              const element = elementRegistry.get(`${ prefix }_FormRef`);
+
+              const businessObject = getBusinessObject(element);
+
+              // when
+              fn(element, { 'camunda:formRef': undefined });
+
+              // then
+              expect(businessObject.get('camunda:formRef')).not.to.exist;
+              expect(businessObject.get('camunda:formRefBinding')).to.equal('latest');
+              expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
+            }));
+
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/camunda-platform/features/modeling/camunda-user-task-forms-diagram.bpmn
+++ b/test/camunda-platform/features/modeling/camunda-user-task-forms-diagram.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fjxb6c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:userTask id="UserTask_FormRef" camunda:formRef="invoice.form" camunda:formRefBinding="version" camunda:formRefVersion="1" />
+    <bpmn:startEvent id="StartEvent_FormRef" camunda:formRef="invoice.form" camunda:formRefBinding="version" camunda:formRefVersion="1" />
+    <bpmn:startEvent id="StartEvent_FormKey" camunda:formKey="embedded:deployment:FORM_NAME.html" />
+    <bpmn:userTask id="UserTask_FormKey" camunda:formKey="embedded:deployment:FORM_NAME.html" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1oynd5u_di" bpmnElement="UserTask_FormRef">
+        <dc:Bounds x="260" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ghin1n_di" bpmnElement="StartEvent_FormRef">
+        <dc:Bounds x="152" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b9cna2_di" bpmnElement="StartEvent_FormKey">
+        <dc:Bounds x="152" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pn8rby_di" bpmnElement="UserTask_FormKey">
+        <dc:Bounds x="260" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
# Changes

* setting `camunda:formKey` deletes `camunda:formRef`, `camunda:formRefBinding` and `camunda:formRefVersion`
* setting `camunda:formRef` deletes `camunda:formKey`
* deleting `camunda:formRef` deletes `camunda:formRefBinding` and `camunda:formRefVersion`
* setting `camunda:formRefBinding` to something other than `version` deletes `camunda:formRefVersion`

Depends on ttps://github.com/camunda/camunda-bpmn-moddle/pull/76
Closes #37
Related to https://github.com/camunda/camunda-modeler/issues/2295