### PR TITLE
feat(camunda-platform): add input output behavior

### DIFF
--- a/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
@@ -1,0 +1,80 @@
+import inherits from 'inherits';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+/**
+ * Camunda BPMN specific `camunda:inputOutput` behavior.
+ */
+export default function UpdateInputOutputBehavior(eventBus, modeling) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  this.postExecute([
+    'element.updateProperties',
+    'element.updateModdleProperties',
+    'properties-panel.update-businessobject-list'
+  ], function(context) {
+    const {
+      element
+    } = context;
+
+    const businessObject = getBusinessObject(element);
+    const inputOutput = getInputOutput(businessObject);
+    const extensionElements = businessObject.get('extensionElements');
+
+    // Remove camunda:inputOutput if there are no input/output parameters anymore.
+    if (inputOutput && isEmpty(inputOutput)) {
+      const filtered = extensionElements.values.filter(function(element) {
+        return element !== inputOutput;
+      });
+
+      modeling.updateModdleProperties(element, extensionElements, {
+        values: filtered
+      });
+    }
+  }, true);
+}
+
+
+UpdateInputOutputBehavior.$inject = [
+  'eventBus',
+  'modeling'
+];
+
+inherits(UpdateInputOutputBehavior, CommandInterceptor);
+
+
+// helper //////////////////
+
+function getInputParameters(inputOutput) {
+  return inputOutput.get('inputParameters');
+}
+
+function getOutputParameters(inputOutput) {
+  return inputOutput.get('outputParameters');
+}
+
+function getInputOutput(businessObject) {
+  return (getExtensionElementsList(businessObject, 'camunda:InputOutput') || [])[0];
+}
+
+function getExtensionElementsList(businessObject, type = undefined) {
+  const elements = ((businessObject.get('extensionElements') &&
+                  businessObject.get('extensionElements').get('values')) || []);
+
+  return (elements.length && type) ?
+    elements.filter((value) => is(value, type)) :
+    elements;
+}
+
+function isEmpty(inputOutput) {
+  const inputParameters = getInputParameters(inputOutput);
+  const outputParameters = getOutputParameters(inputOutput);
+
+  return inputParameters.length === 0 && outputParameters.length === 0;
+}

--- a/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
@@ -60,16 +60,17 @@ function getOutputParameters(inputOutput) {
 }
 
 function getInputOutput(businessObject) {
-  return (getExtensionElementsList(businessObject, 'camunda:InputOutput') || [])[0];
-}
+  const extensionElements = businessObject.get('extensionElements');
 
-function getExtensionElementsList(businessObject, type = undefined) {
-  const elements = ((businessObject.get('extensionElements') &&
-                  businessObject.get('extensionElements').get('values')) || []);
+  if (!extensionElements) {
+    return;
+  }
 
-  return (elements.length && type) ?
-    elements.filter((value) => is(value, type)) :
-    elements;
+  const values = extensionElements.get('values');
+
+  return values.find((value) => {
+    return is(value, 'camunda:InputOutput');
+  });
 }
 
 function isEmpty(inputOutput) {

--- a/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
@@ -27,7 +27,7 @@ export default function UpdateInputOutputBehavior(eventBus, modeling) {
     const inputOutput = getInputOutput(businessObject);
     const extensionElements = businessObject.get('extensionElements');
 
-    // Remove camunda:inputOutput if there are no input/output parameters anymore.
+    // remove camunda:inputOutput if there are no input/output parameters anymore
     if (inputOutput && isEmpty(inputOutput)) {
       const filtered = extensionElements.values.filter(function(element) {
         return element !== inputOutput;

--- a/lib/camunda-platform/features/modeling/behavior/index.js
+++ b/lib/camunda-platform/features/modeling/behavior/index.js
@@ -1,6 +1,7 @@
 import DeleteErrorEventDefinitionBehavior from './DeleteErrorEventDefinitionBehavior';
 import DeleteRetryTimeCycleBehavior from './DeleteRetryTimeCycleBehavior';
 import UpdateCamundaExclusiveBehavior from './UpdateCamundaExclusiveBehavior';
+import UpdateInputOutputBehavior from './UpdateInputOutputBehavior';
 import UpdateResultVariableBehavior from './UpdateResultVariableBehavior';
 import UserTaskFormsBehavior from './UserTaskFormsBehavior';
 
@@ -10,11 +11,13 @@ export default {
     'deleteRetryTimeCycleBehavior',
     'updateCamundaExclusiveBehavior',
     'updateResultVariableBehavior',
+    'updateInputOutputBehavior',
     'userTaskFormsBehavior'
   ],
   deleteErrorEventDefinitionBehavior: [ 'type', DeleteErrorEventDefinitionBehavior ],
   deleteRetryTimeCycleBehavior: [ 'type', DeleteRetryTimeCycleBehavior ],
   updateCamundaExclusiveBehavior: [ 'type', UpdateCamundaExclusiveBehavior ],
   updateResultVariableBehavior: [ 'type', UpdateResultVariableBehavior ],
+  updateInputOutputBehavior: [ 'type', UpdateInputOutputBehavior ],
   userTaskFormsBehavior: [ 'type', UserTaskFormsBehavior ]
 };

--- a/test/camunda-platform/features/modeling/UpdateInputOutputBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UpdateInputOutputBehaviorSpec.js
@@ -1,0 +1,575 @@
+import {
+  bootstrapCamundaPlatformModeler,
+  inject
+} from 'test/TestHelper';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import coreModule from 'bpmn-js/lib/core';
+
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
+
+import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
+import diagramXML from './camunda-input-output-diagram.bpmn';
+
+
+describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', function() {
+
+  const testModules = [
+    camundaPlatformModelingModules,
+    coreModule,
+    modelingModule,
+    propertiesPanelCommandHandler
+  ];
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+  beforeEach(bootstrapCamundaPlatformModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+  describe('element.updateProperties', function() {
+
+    it('should NOT execute if there are still parameters',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_3');
+        const businessObject = getBusinessObject(shape);
+        const extensionElements = businessObject.get('extensionElements');
+
+        const inputOutput = getInputOutput(businessObject);
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        inputOutput.set('inputParameters', []);
+        extensionElements.set('values', [ inputOutput ]);
+
+        // when
+        modeling.updateProperties(shape, {
+          extensionElements
+        });
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      })
+    );
+
+
+    it('should keep other extension elements',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_4');
+        const businessObject = getBusinessObject(shape);
+        const extensionElements = businessObject.get('extensionElements');
+
+        const inputOutput = getInputOutput(businessObject);
+        const properties = getProperties(businessObject);
+
+        // assume
+        expect(getExtensionElementsList(businessObject)).to.have.length(2);
+
+        inputOutput.set('inputParameters', []);
+        extensionElements.set('values', [ inputOutput, properties ]);
+
+        // when
+        modeling.updateProperties(shape, {
+          extensionElements
+        });
+
+        // then
+        expect(getExtensionElementsList(businessObject)).to.have.length(1);
+      })
+    );
+
+
+    describe('delete last input parameter', function() {
+
+      let businessObject;
+
+      beforeEach(inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+        businessObject = getBusinessObject(shape);
+        const extensionElements = businessObject.get('extensionElements');
+
+        const inputOutput = getInputOutput(businessObject);
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        inputOutput.set('inputParameters', []);
+        extensionElements.set('values', [ inputOutput ]);
+
+        // when
+        modeling.updateProperties(shape, {
+          extensionElements
+        });
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+    });
+
+
+    describe('delete last output parameter', function() {
+
+      let businessObject;
+
+      beforeEach(inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_2');
+        businessObject = getBusinessObject(shape);
+        const extensionElements = businessObject.get('extensionElements');
+
+        const inputOutput = getInputOutput(businessObject);
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        inputOutput.set('outputParameters', []);
+        extensionElements.set('values', [ inputOutput ]);
+
+        // when
+        modeling.updateProperties(shape, {
+          extensionElements
+        });
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+    });
+
+  });
+
+
+  describe('element.updateModdleProperties', function() {
+
+    it('should NOT execute if there are still parameters',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_3');
+        const businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        // when
+        modeling.updateModdleProperties(shape, inputOutput, {
+          inputParameters: []
+        });
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      })
+    );
+
+
+    it('should keep other extension elements',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_4');
+        const businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+
+        // assume
+        expect(getExtensionElementsList(businessObject)).to.have.length(2);
+
+        // when
+        modeling.updateModdleProperties(shape, inputOutput, {
+          inputParameters: []
+        });
+
+        // then
+        expect(getExtensionElementsList(businessObject)).to.have.length(1);
+      })
+    );
+
+
+    describe('delete last input parameter', function() {
+
+      let businessObject;
+
+      beforeEach(inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+        businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        // when
+        modeling.updateModdleProperties(shape, inputOutput, {
+          inputParameters: []
+        });
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+    });
+
+
+    describe('delete last output parameter', function() {
+
+      let businessObject;
+
+      beforeEach(inject(function(elementRegistry, modeling) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_2');
+        businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        // when
+        modeling.updateModdleProperties(shape, inputOutput, {
+          outputParameters: []
+        });
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+    });
+
+  });
+
+
+
+  describe('properties-panel.update-businessobject-list', function() {
+
+    it('should NOT execute if there are still parameters',
+      inject(function(elementRegistry, commandStack) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_3');
+        const businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+        const inputParameters = getInputParameters(inputOutput);
+
+        const context = {
+          element: shape,
+          currentObject: inputOutput,
+          propertyName: 'inputParameters',
+          objectsToRemove: inputParameters
+        };
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        // when
+        commandStack.execute('properties-panel.update-businessobject-list', context);
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      })
+    );
+
+
+    it('should keep other extension elements',
+      inject(function(elementRegistry, commandStack) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_4');
+        const businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+        const inputParameters = getInputParameters(inputOutput);
+
+        const context = {
+          element: shape,
+          currentObject: inputOutput,
+          propertyName: 'inputParameters',
+          objectsToRemove: inputParameters
+        };
+
+        // assume
+        expect(getExtensionElementsList(businessObject)).to.have.length(2);
+
+        // when
+        commandStack.execute('properties-panel.update-businessobject-list', context);
+
+        // then
+        expect(getExtensionElementsList(businessObject)).to.have.length(1);
+      })
+    );
+
+
+    describe('delete last input parameter', function() {
+
+      let businessObject;
+
+      beforeEach(inject(function(elementRegistry, commandStack) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_1');
+
+        businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+        const inputParameters = getInputParameters(inputOutput);
+
+        const context = {
+          element: shape,
+          currentObject: inputOutput,
+          propertyName: 'inputParameters',
+          objectsToRemove: inputParameters
+        };
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        // when
+        commandStack.execute('properties-panel.update-businessobject-list', context);
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+    });
+
+
+    describe('delete last output parameter', function() {
+
+      let businessObject;
+
+      beforeEach(inject(function(elementRegistry, commandStack) {
+
+        // given
+        const shape = elementRegistry.get('ServiceTask_2');
+
+        businessObject = getBusinessObject(shape);
+
+        const inputOutput = getInputOutput(businessObject);
+        const outputParameters = getOutputParameters(inputOutput);
+
+        const context = {
+          element: shape,
+          currentObject: inputOutput,
+          propertyName: 'outputParameters',
+          objectsToRemove: outputParameters
+        };
+
+        // assume
+        expect(inputOutput).to.exist;
+
+        // when
+        commandStack.execute('properties-panel.update-businessobject-list', context);
+      }));
+
+
+      it('should execute', inject(function() {
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+
+      it('should undo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.exist;
+      }));
+
+
+      it('should redo', inject(function(commandStack) {
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(getInputOutput(businessObject)).to.not.exist;
+      }));
+
+    });
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function getOutputParameters(inputOutput) {
+  return inputOutput.get('outputParameters');
+}
+
+function getInputParameters(inputOutput) {
+  return inputOutput.get('inputParameters');
+}
+
+function getInputOutput(businessObject) {
+  return (getExtensionElementsList(businessObject, 'camunda:InputOutput') || [])[0];
+}
+
+function getProperties(businessObject) {
+  return (getExtensionElementsList(businessObject, 'camunda:Properties') || [])[0];
+}
+
+function getExtensionElementsList(businessObject, type = undefined) {
+  const elements = ((businessObject.get('extensionElements') &&
+                  businessObject.get('extensionElements').get('values')) || []);
+
+  return (elements.length && type) ?
+    elements.filter((value) => is(value, type)) :
+    elements;
+}

--- a/test/camunda-platform/features/modeling/camunda-input-output-diagram.bpmn
+++ b/test/camunda-platform/features/modeling/camunda-input-output-diagram.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0uf0lod" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0-nightly.20210902" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="Input_1" />
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_2">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:outputParameter name="Output_1" />
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_3">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="Input_1" />
+          <camunda:outputParameter name="Output_1" />
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_4">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="Input_1" />
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="extension" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0m9gwek_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1maqshx_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="160" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w8u78i_di" bpmnElement="ServiceTask_3">
+        <dc:Bounds x="160" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xsfqdb_di" bpmnElement="ServiceTask_4">
+        <dc:Bounds x="160" y="430" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Ensures we clean up empty `camunda:inputOutput` elements.

Related to https://github.com/bpmn-io/bpmn-properties-panel/issues/54