### PR TITLE
Update camunda:FormData

### DIFF
--- a/lib/camunda-platform/features/modeling/behavior/UserTaskGeneratedFormsBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UserTaskGeneratedFormsBehavior.js
@@ -1,0 +1,36 @@
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+
+/**
+ * Camunda BPMN specific user task generated forms behavior removing camunda:FormField#values if camunda:FormField#type
+ * is changed to something other than enum.
+ */
+export default class UserTaskFormsBehavior extends CommandInterceptor {
+  constructor(eventBus) {
+    super(eventBus);
+
+    this.preExecute([
+      'element.updateModdleProperties',
+      'properties-panel.update-businessobject'
+    ], function(context) {
+      let {
+        businessObject,
+        moddleElement,
+        properties
+      } = context;
+
+      businessObject = businessObject || moddleElement;
+
+      if (is(businessObject, 'camunda:FormField')
+        && 'camunda:type' in properties
+        && properties[ 'camunda:type' ] !== 'enum') {
+        properties[ 'camunda:values' ] = undefined;
+      }
+    }, true);
+  }
+}
+
+
+UserTaskFormsBehavior.$inject = [ 'eventBus' ];

--- a/lib/camunda-platform/features/modeling/behavior/UserTaskGeneratedFormsBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UserTaskGeneratedFormsBehavior.js
@@ -1,14 +1,17 @@
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 
 
 /**
- * Camunda BPMN specific user task generated forms behavior removing camunda:FormField#values if camunda:FormField#type
- * is changed to something other than enum.
+ * Camunda BPMN specific user task generated forms behavior.
+ *
+ * 1. Removes camunda:FormField#values if camunda:FormField#type is changed to something other than enum.
+ * 2. Updates camunda:FormData#businessKey if camunda:FormField#id is changed.
+ * 3. Removes camunda:FormData#businessKey if camunda:FormField is removed.
  */
 export default class UserTaskFormsBehavior extends CommandInterceptor {
-  constructor(eventBus) {
+  constructor(eventBus, modeling) {
     super(eventBus);
 
     this.preExecute([
@@ -23,14 +26,92 @@ export default class UserTaskFormsBehavior extends CommandInterceptor {
 
       businessObject = businessObject || moddleElement;
 
-      if (is(businessObject, 'camunda:FormField')
-        && 'camunda:type' in properties
-        && properties[ 'camunda:type' ] !== 'enum') {
+      if (!is(businessObject, 'camunda:FormField')) {
+        return;
+      }
+
+      if ('camunda:type' in properties && properties[ 'camunda:type' ] !== 'enum') {
         properties[ 'camunda:values' ] = undefined;
       }
+    }, true);
+
+    this.preExecute([
+      'element.updateModdleProperties',
+      'properties-panel.update-businessobject'
+    ], function(context) {
+      let {
+        businessObject,
+        element,
+        moddleElement,
+        properties
+      } = context;
+
+      businessObject = businessObject || moddleElement;
+
+      if (!is(businessObject, 'camunda:FormField')) {
+        return;
+      }
+
+      const formData = getFormData(element);
+
+      if ('camunda:id' in properties && isBusinessKey(businessObject, formData)) {
+        modeling.updateModdleProperties(element, formData, {
+          'camunda:businessKey': properties[ 'camunda:id' ]
+        });
+      }
+    }, true);
+
+    this.postExecute('properties-panel.update-businessobject-list', function(context) {
+      const {
+        currentObject: businessObject,
+        element,
+        propertyName,
+        objectsToRemove = []
+      } = context;
+
+      if (!is(businessObject, 'camunda:FormData')
+        || propertyName !== 'fields'
+        || !objectsToRemove.length) {
+        return;
+      }
+
+      const businessKey = businessObject.get('camunda:businessKey');
+
+      if (!businessKey) {
+        return;
+      }
+
+      objectsToRemove.forEach((object) => {
+        if (is(object, 'camunda:FormField') && object.get('camunda:id') === businessKey) {
+          modeling.updateModdleProperties(element, businessObject, {
+            'camunda:businessKey': undefined
+          });
+        }
+      });
     }, true);
   }
 }
 
 
-UserTaskFormsBehavior.$inject = [ 'eventBus' ];
+UserTaskFormsBehavior.$inject = [ 'eventBus', 'modeling' ];
+
+// helpers //////////
+
+function isBusinessKey(formField, formData) {
+  return formField.get('camunda:id') === formData.get('camunda:businessKey');
+}
+
+function getFormData(element) {
+  const businessObject = getBusinessObject(element),
+        extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return;
+  }
+
+  const values = extensionElements.get('values');
+
+  return values.find((value) => {
+    return is(value, 'camunda:FormData');
+  });
+}

--- a/lib/camunda-platform/features/modeling/behavior/index.js
+++ b/lib/camunda-platform/features/modeling/behavior/index.js
@@ -4,6 +4,7 @@ import UpdateCamundaExclusiveBehavior from './UpdateCamundaExclusiveBehavior';
 import UpdateInputOutputBehavior from './UpdateInputOutputBehavior';
 import UpdateResultVariableBehavior from './UpdateResultVariableBehavior';
 import UserTaskFormsBehavior from './UserTaskFormsBehavior';
+import UserTaskGeneratedFormsBehavior from './UserTaskGeneratedFormsBehavior';
 
 export default {
   __init__: [
@@ -12,12 +13,14 @@ export default {
     'updateCamundaExclusiveBehavior',
     'updateResultVariableBehavior',
     'updateInputOutputBehavior',
-    'userTaskFormsBehavior'
+    'userTaskFormsBehavior',
+    'userTaskGeneratedFormsBehavior'
   ],
   deleteErrorEventDefinitionBehavior: [ 'type', DeleteErrorEventDefinitionBehavior ],
   deleteRetryTimeCycleBehavior: [ 'type', DeleteRetryTimeCycleBehavior ],
   updateCamundaExclusiveBehavior: [ 'type', UpdateCamundaExclusiveBehavior ],
   updateResultVariableBehavior: [ 'type', UpdateResultVariableBehavior ],
   updateInputOutputBehavior: [ 'type', UpdateInputOutputBehavior ],
-  userTaskFormsBehavior: [ 'type', UserTaskFormsBehavior ]
+  userTaskFormsBehavior: [ 'type', UserTaskFormsBehavior ],
+  userTaskGeneratedFormsBehavior: [ 'type', UserTaskGeneratedFormsBehavior ]
 };

--- a/test/camunda-platform/features/modeling/UserTaskGeneratedFormsBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UserTaskGeneratedFormsBehaviorSpec.js
@@ -1,0 +1,132 @@
+import {
+  bootstrapCamundaPlatformModeler,
+  inject
+} from 'test/TestHelper';
+
+import {
+  getBpmnJS
+} from 'bpmn-js/test/helper';
+
+import coreModule from 'bpmn-js/lib/core';
+
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
+
+import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
+import diagramXML from './camunda-user-task-generated-forms-diagram.bpmn';
+
+
+describe('camunda-platform/features/modeling - UserTaskGeneratedFormsBehavior', function() {
+
+  const testModules = [
+    camundaPlatformModelingModules,
+    coreModule,
+    modelingModule,
+    propertiesPanelCommandHandler
+  ];
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+  beforeEach(bootstrapCamundaPlatformModeler(diagramXML, {
+    modules: testModules,
+    moddleExtensions
+  }));
+
+  function updateModdleProperties(element, moddleElement, properties) {
+    getBpmnJS().invoke(function(modeling) {
+      modeling.updateModdleProperties(element, moddleElement, properties);
+    });
+  }
+
+  function updateBusinessObject(element, businessObject, properties) {
+    getBpmnJS().invoke(function(commandStack) {
+      commandStack.execute('properties-panel.update-businessobject', {
+        element,
+        businessObject,
+        properties
+      });
+    });
+  }
+
+  [
+    [ 'element.updateModdleProperties', updateModdleProperties ],
+    [ 'properties-panel.update-businessobject', updateBusinessObject ]
+  ].forEach(([ command, fn ]) => {
+
+    describe(command, function() {
+
+      [
+        [ 'start event', 'StartEvent' ],
+        [ 'user task', 'UserTask' ]
+      ].forEach(([ type, prefix ]) => {
+
+        describe('setting camunda:FormField#type to boolean', function() {
+
+          describe(type, function() {
+
+            it('should delete camunda:FormField#values', inject(function(elementRegistry) {
+
+              // when
+              const element = elementRegistry.get(`${ prefix }_1`);
+
+              const businessObject = getFormField(element);
+
+              // when
+              fn(element, businessObject, { 'camunda:type': 'boolean' });
+
+              // then
+              expect(businessObject.get('camunda:values')).to.be.empty;
+            }));
+
+
+            it('should not delete camunda:FormField#values', inject(function(elementRegistry) {
+
+              // when
+              const element = elementRegistry.get(`${ prefix }_1`);
+
+              const businessObject = getFormField(element);
+
+              // when
+              fn(element, businessObject, { 'camunda:type': 'enum' });
+
+              // then
+              expect(businessObject.get('camunda:values')).not.to.be.empty;
+            }));
+
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
+});
+
+// helpers //////////
+
+function getFormField(element, index = 0) {
+  const businessObject = getBusinessObject(element);
+
+  const extensionElements = businessObject.get('extensionElements'),
+        values = extensionElements.get('values');
+
+  const formData = values.find((value) => {
+    return is(value, 'camunda:FormData');
+  });
+
+  return formData.get('camunda:fields')[ index ];
+}

--- a/test/camunda-platform/features/modeling/UserTaskGeneratedFormsBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UserTaskGeneratedFormsBehaviorSpec.js
@@ -75,34 +75,38 @@ describe('camunda-platform/features/modeling - UserTaskGeneratedFormsBehavior', 
 
           describe(type, function() {
 
-            it('should delete camunda:FormField#values', inject(function(elementRegistry) {
+            describe('camunda:FormField#values', function() {
 
-              // when
-              const element = elementRegistry.get(`${ prefix }_1`);
+              it('should delete camunda:FormField#values', inject(function(elementRegistry) {
 
-              const businessObject = getFormField(element);
+                // when
+                const element = elementRegistry.get(`${ prefix }_1`);
 
-              // when
-              fn(element, businessObject, { 'camunda:type': 'boolean' });
+                const businessObject = getFormField(element);
 
-              // then
-              expect(businessObject.get('camunda:values')).to.be.empty;
-            }));
+                // when
+                fn(element, businessObject, { 'camunda:type': 'boolean' });
+
+                // then
+                expect(businessObject.get('camunda:values')).to.be.empty;
+              }));
 
 
-            it('should not delete camunda:FormField#values', inject(function(elementRegistry) {
+              it('should not delete camunda:FormField#values', inject(function(elementRegistry) {
 
-              // when
-              const element = elementRegistry.get(`${ prefix }_1`);
+                // when
+                const element = elementRegistry.get(`${ prefix }_1`);
 
-              const businessObject = getFormField(element);
+                const businessObject = getFormField(element);
 
-              // when
-              fn(element, businessObject, { 'camunda:type': 'enum' });
+                // when
+                fn(element, businessObject, { 'camunda:type': 'enum' });
 
-              // then
-              expect(businessObject.get('camunda:values')).not.to.be.empty;
-            }));
+                // then
+                expect(businessObject.get('camunda:values')).not.to.be.empty;
+              }));
+
+            });
 
           });
 
@@ -110,7 +114,52 @@ describe('camunda-platform/features/modeling - UserTaskGeneratedFormsBehavior', 
 
       });
 
+
+      describe('updating camunda:FormField#id', function() {
+
+        it('should update camunda:FormData#businessKey', inject(function(elementRegistry) {
+
+          // when
+          const element = elementRegistry.get('StartEvent_1');
+
+          const formData = getFormData(element),
+                formField = getFormField(element);
+
+          // when
+          fn(element, formField, { 'camunda:id': 'Foo' });
+
+          // then
+          expect(formData.get('camunda:businessKey')).to.equal('Foo');
+        }));
+
+      });
+
     });
+
+  });
+
+
+  describe('removing camunda:FormField', function() {
+
+    it('should remove camunda:FormData#businessKey', inject(function(commandStack, elementRegistry) {
+
+      // when
+      const element = elementRegistry.get('StartEvent_1');
+
+      const formData = getFormData(element),
+            formField = getFormField(element);
+
+      // when
+      commandStack.execute('properties-panel.update-businessobject-list', {
+        currentObject: formData,
+        element,
+        propertyName: 'fields',
+        objectsToRemove: [ formField ]
+      });
+
+      // then
+      expect(formData.get('camunda:businessKey')).not.to.exist;
+    }));
 
   });
 
@@ -118,15 +167,19 @@ describe('camunda-platform/features/modeling - UserTaskGeneratedFormsBehavior', 
 
 // helpers //////////
 
-function getFormField(element, index = 0) {
+function getFormData(element) {
   const businessObject = getBusinessObject(element);
 
   const extensionElements = businessObject.get('extensionElements'),
         values = extensionElements.get('values');
 
-  const formData = values.find((value) => {
+  return values.find((value) => {
     return is(value, 'camunda:FormData');
   });
+}
+
+function getFormField(element, index = 0) {
+  const formData = getFormData(element);
 
   return formData.get('camunda:fields')[ index ];
 }

--- a/test/camunda-platform/features/modeling/camunda-user-task-generated-forms-diagram.bpmn
+++ b/test/camunda-platform/features/modeling/camunda-user-task-generated-forms-diagram.bpmn
@@ -3,7 +3,7 @@
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" camunda:formKey="embedded:deployment:FORM_NAME.html">
       <bpmn:extensionElements>
-        <camunda:formData>
+        <camunda:formData businessKey="FormField_1">
           <camunda:formField id="FormField_1" type="enum">
             <camunda:value id="Value_1" />
             <camunda:value id="Value_2" />

--- a/test/camunda-platform/features/modeling/camunda-user-task-generated-forms-diagram.bpmn
+++ b/test/camunda-platform/features/modeling/camunda-user-task-generated-forms-diagram.bpmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fjxb6c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" camunda:formKey="embedded:deployment:FORM_NAME.html">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="FormField_1" type="enum">
+            <camunda:value id="Value_1" />
+            <camunda:value id="Value_2" />
+          </camunda:formField>
+        </camunda:formData>
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:userTask id="UserTask_1" camunda:formKey="embedded:deployment:FORM_NAME.html">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="FormField_2" type="enum">
+            <camunda:value id="Value_3" />
+            <camunda:value id="Value_4" />
+          </camunda:formField>
+        </camunda:formData>
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_0b9cna2_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pn8rby_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
# Changes

1. [when changing the type of a `camunda:FormField` to something other than `enum` all values are removed](https://github.com/camunda/camunda-bpmn-js/issues/46)
2. [when removing a `camunda:FormField` or changing its ID the `camunda:FormData`'s `camunda:businessKey` is updated](https://github.com/camunda/camunda-bpmn-js/issues/48)

---

Closes #46
Related to https://github.com/bpmn-io/bpmn-properties-panel/issues/2