### PR TITLE
feat(camunda-cloud): allow replace Message Intermediate Throw and Message End events 

### DIFF
--- a/lib/camunda-cloud/features/popup-menu/ReplaceOptions.js
+++ b/lib/camunda-cloud/features/popup-menu/ReplaceOptions.js
@@ -4,6 +4,7 @@ export const REPLACE_OPTIONS = [
   'replace-with-send-task',
   'replace-with-rule-task',
   'replace-with-message-intermediate-catch',
+  'replace-with-message-intermediate-throw',
   'replace-with-timer-intermediate-catch',
   'replace-with-none-start',
   'replace-with-none-end',
@@ -21,6 +22,7 @@ export const REPLACE_OPTIONS = [
   'replace-with-task',
   'replace-with-manual-task',
   'replace-with-message-start',
+  'replace-with-message-end',
   'replace-with-timer-start',
   'replace-with-none-intermediate-throw',
   'replace-with-none-intermediate-throwing', // only for StartEvent

--- a/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -173,7 +173,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'replace-with-user-task',
         'replace-with-script-task',
         'replace-with-send-task',
-        'replace-with-rule-task'
+        'replace-with-rule-task',
+        'replace-with-manual-task'
       ]);
     }));
 
@@ -198,7 +199,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'replace-with-user-task',
         'replace-with-script-task',
         'replace-with-send-task',
-        'replace-with-rule-task'
+        'replace-with-rule-task',
+        'replace-with-manual-task'
       ]);
     }));
 
@@ -224,7 +226,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'replace-with-user-task',
         'replace-with-script-task',
         'replace-with-send-task',
-        'replace-with-rule-task'
+        'replace-with-rule-task',
+        'replace-with-manual-task'
       ]);
     }));
 
@@ -250,7 +253,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'toggle-sequential-mi',
         'replace-with-user-task',
         'replace-with-script-task',
-        'replace-with-rule-task'
+        'replace-with-rule-task',
+        'replace-with-manual-task'
       ]);
     }));
 
@@ -276,7 +280,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'toggle-sequential-mi',
         'replace-with-user-task',
         'replace-with-send-task',
-        'replace-with-rule-task'
+        'replace-with-rule-task',
+        'replace-with-manual-task'
       ]);
     }));
 
@@ -302,7 +307,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'toggle-sequential-mi',
         'replace-with-user-task',
         'replace-with-script-task',
-        'replace-with-send-task'
+        'replace-with-send-task',
+        'replace-with-manual-task'
       ]);
     }));
 
@@ -327,7 +333,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'toggle-sequential-mi',
         'replace-with-script-task',
         'replace-with-send-task',
-        'replace-with-rule-task'
+        'replace-with-rule-task',
+        'replace-with-manual-task',
       ]);
     }));
 
@@ -344,6 +351,32 @@ describe('camunda-cloud/features - PopupMenu', function() {
       // then
       expectEntries(popupMenu, [
         'replace-with-task',
+        'replace-with-service-task',
+        'replace-with-receive-task',
+        'replace-with-call-activity',
+        'replace-with-collapsed-subprocess',
+        'replace-with-expanded-subprocess',
+        'toggle-parallel-mi',
+        'toggle-sequential-mi',
+        'replace-with-script-task',
+        'replace-with-send-task',
+        'replace-with-rule-task'
+      ]);
+    }));
+
+    it('should contain options for ManualTask', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const manualTask = elementRegistry.get('ManualTask_1');
+
+      // when
+      openPopup(manualTask);
+
+      // then
+      expectEntries(popupMenu, [
+        'replace-with-task',
+        'replace-with-user-task',
         'replace-with-service-task',
         'replace-with-receive-task',
         'replace-with-call-activity',
@@ -438,7 +471,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
         'replace-with-user-task',
         'replace-with-script-task',
         'replace-with-send-task',
-        'replace-with-rule-task'
+        'replace-with-rule-task',
+        'replace-with-manual-task'
       ]);
     }));
 

--- a/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -66,12 +66,14 @@ describe('camunda-cloud/features - PopupMenu', function() {
 
       const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
             intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
-            errorEndEventEntry = queryEntry(popupMenu, 'replace-with-error-end');
+            errorEndEventEntry = queryEntry(popupMenu, 'replace-with-error-end'),
+            messageEndEventEntry = queryEntry(popupMenu, 'replace-with-message-end');
 
       // then
       expect(startEventEntry).to.exist;
       expect(intermediateEventEntry).to.exist;
       expect(errorEndEventEntry).to.exist;
+      expect(messageEndEventEntry).to.exist;
     }));
 
 
@@ -86,13 +88,15 @@ describe('camunda-cloud/features - PopupMenu', function() {
       const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
             endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
             intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
-            messageEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-catch');
+            messageEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-catch'),
+            messageThrowEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-throw');
 
       // then
       expect(startEventEntry).to.exist;
       expect(endEventEntry).to.exist;
       expect(intermediateEventEntry).to.exist;
       expect(messageEventEntry).to.exist;
+      expect(messageThrowEventEntry).to.exist;
     }));
 
 
@@ -107,13 +111,15 @@ describe('camunda-cloud/features - PopupMenu', function() {
       const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
             endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
             intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
-            timerEventEntry = queryEntry(popupMenu, 'replace-with-timer-intermediate-catch');
+            timerEventEntry = queryEntry(popupMenu, 'replace-with-timer-intermediate-catch'),
+            messageThrowEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-throw');
 
       // then
       expect(startEventEntry).to.exist;
       expect(endEventEntry).to.exist;
       expect(intermediateEventEntry).to.exist;
       expect(timerEventEntry).to.exist;
+      expect(messageThrowEventEntry).to.exist;
     }));
 
 

--- a/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -122,6 +122,48 @@ describe('camunda-cloud/features - PopupMenu', function() {
       expect(messageThrowEventEntry).to.exist;
     }));
 
+    it('should contain options for MessageThrowEvent', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const messageThrowEvent = elementRegistry.get('MessageThrowEvent_1');
+
+      openPopup(messageThrowEvent);
+
+      const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
+            endEventEntry = queryEntry(popupMenu, 'replace-with-none-end'),
+            intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
+            timerEventEntry = queryEntry(popupMenu, 'replace-with-timer-intermediate-catch'),
+            messageCatchEventEntry = queryEntry(popupMenu, 'replace-with-message-intermediate-catch');
+
+      // then
+      expect(startEventEntry).to.exist;
+      expect(endEventEntry).to.exist;
+      expect(intermediateEventEntry).to.exist;
+      expect(timerEventEntry).to.exist;
+      expect(messageCatchEventEntry).to.exist;
+    }));
+
+    it('should contain options for MessageEndEvent', inject(function(
+        popupMenu, elementRegistry) {
+
+      // given
+      const messageEndEvent = elementRegistry.get('MessageEndEvent_1');
+
+      openPopup(messageEndEvent);
+
+      const startEventEntry = queryEntry(popupMenu, 'replace-with-none-start'),
+            intermediateEventEntry = queryEntry(popupMenu, 'replace-with-none-intermediate-throw'),
+            errorEndEventEntry = queryEntry(popupMenu, 'replace-with-error-end'),
+            endEventEntry = queryEntry(popupMenu, 'replace-with-none-end');
+
+      // then
+      expect(startEventEntry).to.exist;
+      expect(intermediateEventEntry).to.exist;
+      expect(errorEndEventEntry).to.exist;
+      expect(endEventEntry).to.exist;
+    }));
+
 
     it('should contain options for BoundaryEvent', inject(function(
         popupMenu, elementRegistry) {

--- a/test/fixtures/diagram.bpmn
+++ b/test/fixtures/diagram.bpmn
@@ -14,9 +14,6 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">durationa</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:intermediateCatchEvent id="MessageEvent_1">
-      <bpmn:messageEventDefinition />
-    </bpmn:intermediateCatchEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1" />
     <bpmn:parallelGateway id="ParallelGateway_1" />
     <bpmn:eventBasedGateway id="EventBasedGateway_1">
@@ -39,6 +36,15 @@
     <bpmn:sendTask id="SendTask_1" />
     <bpmn:businessRuleTask id="BusinessRuleTask_1" />
     <bpmn:scriptTask id="ScriptTask_1" />
+    <bpmn:intermediateCatchEvent id="MessageEvent_1">
+      <bpmn:messageEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="MessageThrowEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_03nnim1" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="MessageEndEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1eutapf" />
+    </bpmn:endEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1lw37ec">
@@ -82,14 +88,11 @@
       <bpmndi:BPMNShape id="ReceiveTask_1tj6cz3_di" bpmnElement="MessageTask_2">
         <dc:Bounds x="469" y="464" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0gbf9f0_di" bpmnElement="SendTask_1">
-        <dc:Bounds x="1140" y="100" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0u09skh_di" bpmnElement="MessageThrowEvent_1">
+        <dc:Bounds x="209" y="162" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1uhf79k_di" bpmnElement="BusinessRuleTask_1">
-        <dc:Bounds x="1140" y="200" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1f6e087_di" bpmnElement="ScriptTask_1">
-        <dc:Bounds x="1140" y="300" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_12pwnop_di" bpmnElement="MessageEndEvent_1">
+        <dc:Bounds x="209" y="256" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_1xr3isb_di" bpmnElement="SubProcess_1" isExpanded="false">
         <dc:Bounds x="307" y="186" width="100" height="80" />
@@ -114,6 +117,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0d0hwi8_di" bpmnElement="ManualTask_1">
         <dc:Bounds x="200" y="464" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gbf9f0_di" bpmnElement="SendTask_1">
+        <dc:Bounds x="1140" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1uhf79k_di" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="1140" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f6e087_di" bpmnElement="ScriptTask_1">
+        <dc:Bounds x="1140" y="300" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_0be94jf_di" bpmnElement="BoundaryEvent_1">
         <dc:Bounds x="342" y="144" width="36" height="36" />

--- a/test/fixtures/diagram.bpmn
+++ b/test/fixtures/diagram.bpmn
@@ -35,6 +35,7 @@
     <bpmn:task id="Task_1" />
     <bpmn:callActivity id="CallActivity_1" />
     <bpmn:userTask id="UserTask_1" />
+    <bpmn:manualTask id="ManualTask_1" />
     <bpmn:sendTask id="SendTask_1" />
     <bpmn:businessRuleTask id="BusinessRuleTask_1" />
     <bpmn:scriptTask id="ScriptTask_1" />
@@ -110,6 +111,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1yr5rto_di" bpmnElement="UserTask_1">
         <dc:Bounds x="1000" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d0hwi8_di" bpmnElement="ManualTask_1">
+        <dc:Bounds x="200" y="464" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_0be94jf_di" bpmnElement="BoundaryEvent_1">
         <dc:Bounds x="342" y="144" width="36" height="36" />


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/2420

Also adds tests related to replacing tasks with ManualTask, missing in https://github.com/camunda/camunda-bpmn-js/pull/49  