### PR TITLE
Update properties panel for Message End Event and Message Throw Event

### DIFF
--- a/lib/camunda-cloud/features/properties-provider/parts/HeadersProps.js
+++ b/lib/camunda-cloud/features/properties-provider/parts/HeadersProps.js
@@ -5,8 +5,13 @@ import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
 import cmdHelper from 'bpmn-js-properties-panel/lib/helper/CmdHelper';
 
 import {
-  isAny
-} from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  isZeebeServiceTask
+} from '../../../helper/ZeebeServiceTaskHelper.js';
+
 
 export default function(group, element, bpmnFactory, translate) {
 
@@ -43,8 +48,5 @@ export default function(group, element, bpmnFactory, translate) {
 // helpers ////////////////
 
 function canHaveHeaders(element) {
-  return isAny(element, [
-    'zeebe:ZeebeServiceTask',
-    'bpmn:UserTask'
-  ]);
+  return is(element, 'bpmn:UserTask') || isZeebeServiceTask(element);
 }

--- a/lib/camunda-cloud/features/properties-provider/parts/MessageProps.js
+++ b/lib/camunda-cloud/features/properties-provider/parts/MessageProps.js
@@ -7,11 +7,16 @@ import {
   isEventSubProcess
 } from 'bpmn-js/lib/util/DiUtil';
 
+import {
+  isZeebeServiceTask
+} from '../../../helper/ZeebeServiceTaskHelper.js';
+
 import eventDefinitionHelper from 'bpmn-js-properties-panel/lib/helper/EventDefinitionHelper';
 
 import message from 'bpmn-js-properties-panel/lib/provider/bpmn/parts/implementation/MessageEventDefinition';
 
 import referenceExtensionElementProperty from './implementation/ElementReferenceExtensionElementProperty';
+
 
 export default function(group, element, bpmnFactory, translate) {
 
@@ -28,7 +33,7 @@ export default function(group, element, bpmnFactory, translate) {
       extensionElement: 'zeebe:Subscription',
       shouldValidate: true
     }));
-  } else if (messageEventDefinition) {
+  } else if (messageEventDefinition && !isZeebeServiceTask(element)) {
     message(group, element, bpmnFactory, messageEventDefinition, translate);
     if (!is(element, 'bpmn:StartEvent') || isEventSubProcess(parent)) {
 

--- a/lib/camunda-cloud/features/properties-provider/parts/TaskDefinitionProps.js
+++ b/lib/camunda-cloud/features/properties-provider/parts/TaskDefinitionProps.js
@@ -3,17 +3,21 @@ import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
 import cmdHelper from 'bpmn-js-properties-panel/lib/helper/CmdHelper';
 
 import {
-  getBusinessObject,
-  is
+  getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  isZeebeServiceTask
+} from '../../../helper/ZeebeServiceTaskHelper.js';
 
 import entryFactory from 'bpmn-js-properties-panel/lib/factory/EntryFactory';
 
 import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
 
+
 export default function(group, element, bpmnFactory, translate) {
 
-  if (!is(element, 'zeebe:ZeebeServiceTask')) {
+  if (!isZeebeServiceTask(element)) {
     return;
   }
 

--- a/lib/camunda-cloud/helper/InputOutputHelper.js
+++ b/lib/camunda-cloud/helper/InputOutputHelper.js
@@ -6,6 +6,10 @@ import {
   isAny
 } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 
+import {
+  isZeebeServiceTask
+} from './ZeebeServiceTaskHelper';
+
 import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
 
 import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
@@ -102,11 +106,10 @@ export function isInputOutputSupported(element) {
    */
 export function areInputParametersSupported(element) {
   return isAny(element, [
-    'zeebe:ZeebeServiceTask',
     'bpmn:UserTask',
     'bpmn:SubProcess',
     'bpmn:CallActivity'
-  ]);
+  ]) || isZeebeServiceTask(element);
 }
 
 /**

--- a/lib/camunda-cloud/helper/ZeebeServiceTaskHelper.js
+++ b/lib/camunda-cloud/helper/ZeebeServiceTaskHelper.js
@@ -1,0 +1,24 @@
+import {
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import eventDefinitionHelper from 'bpmn-js-properties-panel/lib/helper/EventDefinitionHelper';
+
+
+export function isZeebeServiceTask(element) {
+  if (!is(element, 'zeebe:ZeebeServiceTask')) return false;
+
+  if (is(element, 'bpmn:EndEvent') || is(element, 'bpmn:IntermediateThrowEvent')) {
+    return !!eventDefinitionHelper.getMessageEventDefinition(element);
+  }
+
+  return true;
+}
+
+export function isMessageEndEvent(element) {
+  return is(element, 'bpmn:EndEvent') && !!eventDefinitionHelper.getMessageEventDefinition(element);
+}
+
+export function isMessageThrowEvent(element) {
+  return is(element, 'bpmn:IntermediateThrowEvent') && !!eventDefinitionHelper.getMessageEventDefinition(element);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6075,9 +6075,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.7.1.tgz",
-      "integrity": "sha512-XUUaGKY/w6QcxgtHPMgy8wt9yhu2BJ17ahjEz6pTr1wosdKra4pq/akF1XXPpUYSEfEswtyK4j0lWT1cu51lKw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.8.0.tgz",
+      "integrity": "sha512-1wly1tG5KB3rbF2OeCuubqsosmR9nPkhvwfi1Wq/qqfChCHLvbfZNny4a/fbxKefTCSlRvxJxxAwjPf1KBrUBg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "diagram-js-origin": "^1.3.2",
     "inherits": "^2.0.4",
     "min-dash": "^3.7.0",
-    "zeebe-bpmn-moddle": "^0.7.1"
+    "zeebe-bpmn-moddle": "^0.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",

--- a/test/camunda-cloud/features/properties-provider/PropertiesProvider.bpmn
+++ b/test/camunda-cloud/features/properties-provider/PropertiesProvider.bpmn
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0rxge3k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0rxge3k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
   <bpmn:process id="Process_1ianoxh" isExecutable="true">
-    <bpmn:endEvent id="EndEvent_1" />
     <bpmn:serviceTask id="ServiceTask_1">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
@@ -44,23 +43,25 @@
       </bpmn:extensionElements>
       <bpmn:multiInstanceLoopCharacteristics />
     </bpmn:businessRuleTask>
+    <bpmn:endEvent id="MessageEndEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0kzfqp4" />
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="ThrowEvent_1" />
+    <bpmn:intermediateThrowEvent id="MessageThrowEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0nqubrf" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="EndEvent_1" />
+    <bpmn:startEvent id="MessageStartEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1vn4ehz" />
+    </bpmn:startEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1ianoxh">
-      <bpmndi:BPMNShape id="EndEvent_1fd589l_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="312" y="99" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0lveymx_di" bpmnElement="ServiceTask_1">
         <dc:Bounds x="160" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1y2b1aq_di" bpmnElement="SendTask_1">
-        <dc:Bounds x="580" y="90" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_14xapja_di" bpmnElement="ScriptTask_1">
-        <dc:Bounds x="720" y="90" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0h4wcpz_di" bpmnElement="BusinessRuleTask_1">
-        <dc:Bounds x="860" y="90" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_1t1uk80_di" bpmnElement="MessageStartEvent_1">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0o2zhob_di" bpmnElement="SubProcess_1" isExpanded="true">
         <dc:Bounds x="155" y="220" width="350" height="200" />
@@ -76,6 +77,27 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
         <dc:Bounds x="330" y="470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1y2b1aq_di" bpmnElement="SendTask_1">
+        <dc:Bounds x="580" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14xapja_di" bpmnElement="ScriptTask_1">
+        <dc:Bounds x="720" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0h4wcpz_di" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="860" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1fd589l_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="312" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08vs8te_di" bpmnElement="MessageEndEvent_1">
+        <dc:Bounds x="312" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1b1vukh_di" bpmnElement="ThrowEvent_1">
+        <dc:Bounds x="372" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08ub9mi_di" bpmnElement="MessageThrowEvent_1">
+        <dc:Bounds x="372" y="152" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/camunda-cloud/features/properties-provider/PropertiesProviderSpec.js
+++ b/test/camunda-cloud/features/properties-provider/PropertiesProviderSpec.js
@@ -95,6 +95,47 @@ describe('camunda-cloud/features - PropertiesProvider', function() {
       shouldHaveGroup(container, 'general', 'multiInstance');
     }));
 
+
+    it('should not show message props', inject(function(selection, elementRegistry) {
+
+      // given
+      const shape = elementRegistry.get('MessageEndEvent_1');
+
+      // when
+      selection.select(shape);
+
+      // then
+      shouldNotHaveDetailsProperty(container, 'event-definitions-message');
+    }));
+
+
+    it('should show task definition props', inject(function(selection, elementRegistry) {
+
+      // given
+      const shape = elementRegistry.get('MessageEndEvent_1');
+
+      // when
+      selection.select(shape);
+
+      // then
+      shouldHaveDetailsProperty(container, 'taskDefinitionType');
+      shouldHaveDetailsProperty(container, 'taskDefinitionRetries');
+    }));
+
+
+    it('should not show task definition props', inject(function(selection, elementRegistry) {
+
+      // given
+      const shape = elementRegistry.get('MessageStartEvent_1');
+
+      // when
+      selection.select(shape);
+
+      // then
+      shouldNotHaveDetailsProperty(container, 'taskDefinitionType');
+      shouldNotHaveDetailsProperty(container, 'taskDefinitionRetries');
+    }));
+
   });
 
 
@@ -120,15 +161,38 @@ describe('camunda-cloud/features - PropertiesProvider', function() {
     it('should show headers group', inject(function(selection, elementRegistry) {
 
       // given
-      const shape = elementRegistry.get('ServiceTask_1');
+      const shapes = [
+        elementRegistry.get('ServiceTask_1'),
+        elementRegistry.get('MessageEndEvent_1'),
+        elementRegistry.get('MessageThrowEvent_1'),
+      ];
 
       // when
-      selection.select(shape);
+      for (const shape of shapes) {
+        selection.select(shape);
 
-      // then
-      shouldHaveGroup(container, 'headers', 'headers-properties');
+        // then
+        shouldHaveGroup(container, 'headers', 'headers-properties');
+      }
     }));
 
+
+    it('should not show headers group', inject(async function(selection, elementRegistry) {
+
+      // given
+      const shapes = [
+        elementRegistry.get('EndEvent_1'),
+        elementRegistry.get('ThrowEvent_1'),
+      ];
+
+      // when
+      for (const shape of shapes) {
+        selection.select(shape);
+
+        // then
+        shouldNotHaveGroup(container, 'headers', 'headers-properties');
+      }
+    }));
   });
 
 
@@ -219,7 +283,26 @@ describe('camunda-cloud/features - PropertiesProvider', function() {
         shouldHaveGroup(container, 'output', 'output');
       }));
 
+
+      it('should show for zeebeServiceTask events', inject(function(selection, elementRegistry) {
+
+        // given
+        const shapes = [
+          elementRegistry.get('MessageEndEvent_1'),
+          elementRegistry.get('MessageThrowEvent_1'),
+        ];
+
+        // when
+        for (const shape of shapes) {
+          selection.select(shape);
+
+          // then
+          shouldHaveGroup(container, 'input', 'input');
+          shouldHaveGroup(container, 'output', 'output');
+        }
+      }));
     });
+
 
     describe('output group but not input group', function() {
 
@@ -240,7 +323,7 @@ describe('camunda-cloud/features - PropertiesProvider', function() {
       it('should show for events', inject(function(selection, elementRegistry) {
 
         // given
-        const shape = elementRegistry.get('EndEvent_1');
+        const shape = elementRegistry.get('MessageStartEvent_1');
 
         // when
         selection.select(shape);
@@ -268,6 +351,11 @@ function getGroup(container, tabName, groupName) {
   return domQuery(`div[data-group="${groupName}"]`, tab);
 }
 
+function getProperty(container, tabName, groupName, dataEntry) {
+  const group = getGroup(container, tabName, groupName);
+  return domQuery(`div[data-entry="${dataEntry}"]`, group);
+}
+
 const shouldHaveGroup = (container, tabName, groupName) => {
   const group = getGroup(container, tabName, groupName);
   expect(group).to.exist;
@@ -277,4 +365,15 @@ const shouldHaveGroup = (container, tabName, groupName) => {
 const shouldNotHaveGroup = (container, tabName, groupName) => {
   const group = getGroup(container, tabName, groupName);
   expect(domClasses(group).has('bpp-hidden')).to.be.true;
+};
+
+const shouldHaveDetailsProperty = (container, property) => {
+  const prop = getProperty(container, 'general', 'details', property);
+  expect(prop).to.exist;
+  expect(domClasses(prop).has('bpp-hidden')).to.be.false;
+};
+
+const shouldNotHaveDetailsProperty = (container, property) => {
+  const prop = getProperty(container, 'general', 'details', property);
+  expect(prop).to.not.exist;
 };


### PR DESCRIPTION
- Bump `zeebe-bpmn-moddle` to v0.8.0
- Remove message properties for Message End Event and Message Throw Event
- Add ZeebeServiceTask properties for  Message End Event and Message Throw Event

__Screenshot__
Normal end event:
<img width="349" alt="Screenshot 2021-09-23 at 15 28 59" src="https://user-images.githubusercontent.com/25825387/134515921-60e42e01-e6af-4449-bb99-3b7a12e5f148.png">

Message end event:
<img width="368" alt="Screenshot 2021-09-23 at 15 24 20" src="https://user-images.githubusercontent.com/25825387/134515349-7c5d6680-f78c-4e65-b4aa-c203afcbbc62.png">
