### PR TITLE
Refactor Behaviors to Not Monkey Patch

### DIFF
--- a/lib/camunda-cloud/features/modeling/behavior/CreateZeebeBoundaryEventBehavior.js
+++ b/lib/camunda-cloud/features/modeling/behavior/CreateZeebeBoundaryEventBehavior.js
@@ -1,5 +1,3 @@
-import inherits from 'inherits';
-
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import {
@@ -7,74 +5,72 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-const HIGH_PRIORITY = 15000;
+const HIGH_PRIORITY = 5000;
+
 
 /**
- * BPMN specific create zeebe boundary event behavior
+ * Zeebe BPMN specific behavior for creating boundary events.
  */
-export default function CreateZeebeBoundaryEventBehavior(
-    eventBus, elementFactory, bpmnFactory) {
+export default class CreateZeebeBoundaryEventBehavior extends CommandInterceptor {
+  constructor(bpmnFactory, elementFactory, eventBus) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
+    /**
+     * Replace intermediate catch event with boundary event when attaching it to a shape.
+     */
+    this.preExecute('shape.create', HIGH_PRIORITY, function(context) {
+      const {
+        shape,
+        host
+      } = context;
 
-  /**
-   * replace intermediate catch event with boundary event when
-   * attaching it to a shape
-   */
-  this.preExecute('shape.create', HIGH_PRIORITY, function(context) {
-    const {
-      shape,
-      host
-    } = context;
+      const businessObject = getBusinessObject(shape);
 
-    const businessObject = getBusinessObject(shape);
-
-    let attrs = {
-      cancelActivity: true
-    };
-
-    let newBusinessObject,
-        hostBusinessObject,
-        boundaryEvent,
-        eventDefinitions;
-
-    if (!host || !is(shape, 'bpmn:IntermediateCatchEvent')) {
-      return;
-    }
-
-    hostBusinessObject = getBusinessObject(host);
-
-    attrs = {
-      attachedToRef: hostBusinessObject,
-      ...attrs
-    };
-
-    eventDefinitions = businessObject.eventDefinitions;
-
-    newBusinessObject = bpmnFactory.create('bpmn:BoundaryEvent', attrs);
-
-    boundaryEvent = {
-      type: 'bpmn:BoundaryEvent',
-      businessObject: newBusinessObject,
-    };
-
-    if (eventDefinitions && eventDefinitions[0]) {
-      boundaryEvent = {
-        ...boundaryEvent,
-        eventDefinitionType: eventDefinitions[0].$type
+      let attrs = {
+        cancelActivity: true
       };
-    }
 
-    context.shape = elementFactory.createShape(boundaryEvent);
+      let newBusinessObject,
+          hostBusinessObject,
+          boundaryEvent,
+          eventDefinitions;
 
-  }, true);
+      if (!host || !is(shape, 'bpmn:IntermediateCatchEvent')) {
+        return;
+      }
+
+      hostBusinessObject = getBusinessObject(host);
+
+      attrs = {
+        ...attrs,
+        attachedToRef: hostBusinessObject
+      };
+
+      eventDefinitions = businessObject.eventDefinitions;
+
+      newBusinessObject = bpmnFactory.create('bpmn:BoundaryEvent', attrs);
+
+      boundaryEvent = {
+        type: 'bpmn:BoundaryEvent',
+        businessObject: newBusinessObject,
+      };
+
+      if (eventDefinitions && eventDefinitions[0]) {
+        boundaryEvent = {
+          ...boundaryEvent,
+          eventDefinitionType: eventDefinitions[0].$type
+        };
+      }
+
+      context.shape = elementFactory.createShape(boundaryEvent);
+
+    }, true);
+
+  }
 }
 
-
 CreateZeebeBoundaryEventBehavior.$inject = [
-  'eventBus',
+  'bpmnFactory',
   'elementFactory',
-  'bpmnFactory'
+  'eventBus'
 ];
-
-inherits(CreateZeebeBoundaryEventBehavior, CommandInterceptor);

--- a/lib/camunda-cloud/features/modeling/behavior/CreateZeebeCallActivityBehavior.js
+++ b/lib/camunda-cloud/features/modeling/behavior/CreateZeebeCallActivityBehavior.js
@@ -1,14 +1,8 @@
-import inherits from 'inherits';
-
-import {
-  has
-} from 'min-dash';
+import { has } from 'min-dash';
 
 import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
 
-import {
-  getCalledElement
-} from '../../../helper/CalledElementHelper';
+import { getCalledElement } from '../../../helper/CalledElementHelper';
 
 import {
   getBusinessObject,
@@ -17,68 +11,64 @@ import {
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-const HIGH_PRIORITY = 15000;
+const HIGH_PRIORITY = 5000;
+
 
 /**
- * BPMN specific create zeebe call activity behavior
+ * Zeebe BPMN specific behavior for creating call activities.
  */
-export default function CreateZeebeCallActivityBehavior(bpmnFactory, eventBus, modeling) {
+export default class CreateZeebeCallActivityBehavior extends CommandInterceptor {
+  constructor(bpmnFactory, eventBus, modeling) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
+    /**
+     * Add zeebe:CalledElement extension element with zeebe:propagateAllChildVariables attribute = false
+     * when creating bpmn:CallActivity.
+     */
+    this.postExecuted('shape.create', HIGH_PRIORITY, function(context) {
+      const { shape } = context;
 
-  /**
-   * add a zeebe:calledElement extensionElement with
-   * propagateAllChildVariables attribute = false when creating
-   * a bpmn:callActivity
-   */
-  this.postExecuted('shape.create', HIGH_PRIORITY, function(context) {
-    const {
-      shape
-    } = context;
-
-    if (!is(shape, 'bpmn:CallActivity')) {
-      return;
-    }
-
-    const businessObject = getBusinessObject(shape);
-
-    let calledElement = getCalledElement(businessObject);
-
-    if (!calledElement) {
-      calledElement = bpmnFactory.create('zeebe:CalledElement', {
-        propagateAllChildVariables: false
-      });
-
-      let extensionElements = businessObject.get('extensionElements');
-
-      if (!extensionElements) {
-        extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, businessObject, bpmnFactory);
-
-        modeling.updateProperties(shape, { extensionElements });
+      if (!is(shape, 'bpmn:CallActivity')) {
+        return;
       }
 
-      modeling.updateModdleProperties(shape, extensionElements, {
-        values: [
-          ...(extensionElements.values || []),
-          calledElement
-        ]
-      });
-    } else if (!has(calledElement, 'propagateAllChildVariables')) {
+      const businessObject = getBusinessObject(shape);
 
-      // handle existing bpmn:CallActivity
-      modeling.updateModdleProperties(shape, calledElement, {
-        propagateAllChildVariables: false
-      });
-    }
-  }, true);
+      let calledElement = getCalledElement(businessObject);
 
+      if (!calledElement) {
+        calledElement = bpmnFactory.create('zeebe:CalledElement', {
+          propagateAllChildVariables: false
+        });
+
+        let extensionElements = businessObject.get('extensionElements');
+
+        if (!extensionElements) {
+          extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, businessObject, bpmnFactory);
+
+          modeling.updateProperties(shape, { extensionElements });
+        }
+
+        modeling.updateModdleProperties(shape, extensionElements, {
+          values: [
+            ...(extensionElements.values || []),
+            calledElement
+          ]
+        });
+      } else if (!has(calledElement, 'propagateAllChildVariables')) {
+
+        // if zeebe:CalledElement exist set zeebe:propagateAllChildVariables to false
+        modeling.updateModdleProperties(shape, calledElement, {
+          propagateAllChildVariables: false
+        });
+      }
+    }, true);
+
+  }
 }
-
 
 CreateZeebeCallActivityBehavior.$inject = [
   'bpmnFactory',
   'eventBus',
   'modeling'
 ];
-
-inherits(CreateZeebeCallActivityBehavior, CommandInterceptor);

--- a/lib/camunda-cloud/features/modeling/behavior/CreateZeebeCallActivityBehavior.js
+++ b/lib/camunda-cloud/features/modeling/behavior/CreateZeebeCallActivityBehavior.js
@@ -22,8 +22,7 @@ const HIGH_PRIORITY = 15000;
 /**
  * BPMN specific create zeebe call activity behavior
  */
-export default function CreateZeebeCallActivityBehavior(
-    eventBus, bpmnFactory) {
+export default function CreateZeebeCallActivityBehavior(bpmnFactory, eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
@@ -41,37 +40,45 @@ export default function CreateZeebeCallActivityBehavior(
       return;
     }
 
-    const bo = getBusinessObject(shape);
+    const businessObject = getBusinessObject(shape);
 
-    // Reuse ExtensionElement if existing
-    const extensionElements = bo.get('extensionElements') ||
-      elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, bo, bpmnFactory);
-
-    // Ensure we have a calledElement
-    let calledElement = getCalledElement(bo);
+    let calledElement = getCalledElement(businessObject);
 
     if (!calledElement) {
-      calledElement = bpmnFactory.create('zeebe:CalledElement', {});
-      calledElement.propagateAllChildVariables = false;
+      calledElement = bpmnFactory.create('zeebe:CalledElement', {
+        propagateAllChildVariables: false
+      });
 
-      extensionElements.get('values').push(
-        calledElement
-      );
+      let extensionElements = businessObject.get('extensionElements');
 
-      bo.extensionElements = extensionElements;
+      if (!extensionElements) {
+        extensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, businessObject, bpmnFactory);
 
-      // Handle existing callActivities
+        modeling.updateProperties(shape, { extensionElements });
+      }
+
+      modeling.updateModdleProperties(shape, extensionElements, {
+        values: [
+          ...(extensionElements.values || []),
+          calledElement
+        ]
+      });
     } else if (!has(calledElement, 'propagateAllChildVariables')) {
-      calledElement.propagateAllChildVariables = false;
-    }
 
+      // handle existing bpmn:CallActivity
+      modeling.updateModdleProperties(shape, calledElement, {
+        propagateAllChildVariables: false
+      });
+    }
   }, true);
+
 }
 
 
 CreateZeebeCallActivityBehavior.$inject = [
+  'bpmnFactory',
   'eventBus',
-  'bpmnFactory'
+  'modeling'
 ];
 
 inherits(CreateZeebeCallActivityBehavior, CommandInterceptor);

--- a/lib/camunda-cloud/features/modeling/behavior/FormDefinitionBehavior.js
+++ b/lib/camunda-cloud/features/modeling/behavior/FormDefinitionBehavior.js
@@ -1,6 +1,4 @@
 
-import inherits from 'inherits';
-
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
@@ -21,103 +19,102 @@ import {
 
 
 /**
- * Zeebe specific form definition behavior.
+ * Zeebe BPMN specific form definition behavior.
  */
-export default function FormDefinitionBehavior(bpmnFactory, eventBus, modeling) {
+export default class FormDefinitionBehavior extends CommandInterceptor {
+  constructor(bpmnFactory, eventBus, modeling) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
+    /**
+     * Remove zeebe:UserTaskForm on user task removed.
+     */
+    this.postExecute('shape.delete', function(context) {
+      const {
+        oldParent,
+        shape
+      } = context;
 
-  /**
-   * ensures a zeebe:userTaskForm is cleaned up when user task got removed
-   */
-  this.postExecute('shape.delete', function(context) {
-    const {
-      shape,
-      oldParent
-    } = context;
+      const rootElement = getRootElement(oldParent);
 
-    const rootElement = getRootElement(oldParent);
+      const userTaskForm = getUserTaskForm(shape, rootElement);
 
-    const userTaskForm = getUserTaskForm(shape, rootElement);
+      if (!is(shape, 'bpmn:UserTask') || !userTaskForm) {
+        return;
+      }
 
-    if (!is(shape, 'bpmn:UserTask') || !userTaskForm) {
-      return;
-    }
+      const rootExtensionElements = rootElement.get('extensionElements');
 
-    const rootExtensionElements = rootElement.get('extensionElements');
+      const values = rootExtensionElements.get('values').filter((element) => {
+        return element !== userTaskForm;
+      });
 
-    const values = rootExtensionElements.get('values').filter((element) => {
-      return element !== userTaskForm;
-    });
-
-    modeling.updateModdleProperties(shape, rootExtensionElements, { values });
-  }, true);
+      modeling.updateModdleProperties(shape, rootExtensionElements, { values });
+    }, true);
 
 
-  /**
-   * create fresh new copied form definition + user task form
-   */
-  this.postExecute('shape.create', function(context) {
-    const {
-      shape,
-    } = context;
+    /**
+     * Create new zeebe:FormDefinition and zeebe:UserTaskForm on user task created.
+     */
+    this.postExecute('shape.create', function(context) {
+      const { shape } = context;
 
-    const oldFormDefinition = getFormDefinition(shape);
+      const oldFormDefinition = getFormDefinition(shape);
 
-    if (!is(shape, 'bpmn:UserTask') || !oldFormDefinition) {
-      return;
-    }
+      if (!is(shape, 'bpmn:UserTask') || !oldFormDefinition) {
+        return;
+      }
 
-    const oldUserTaskForm = getUserTaskForm(shape);
+      const oldUserTaskForm = getUserTaskForm(shape);
 
-    const rootElement = getRootElement(shape);
+      const rootElement = getRootElement(shape);
 
-    const businessObject = getBusinessObject(shape);
+      const businessObject = getBusinessObject(shape);
 
-    const extensionElements = businessObject.get('extensionElements');
+      const extensionElements = businessObject.get('extensionElements');
 
-    let rootExtensionElements = rootElement.get('extensionElements');
+      let rootExtensionElements = rootElement.get('extensionElements');
 
-    // (1) ensure extension elements in root
-    if (!rootExtensionElements) {
-      rootExtensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, rootElement, bpmnFactory);
+      // (1) ensure extension elements exists
+      if (!rootExtensionElements) {
+        rootExtensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, rootElement, bpmnFactory);
 
-      modeling.updateModdleProperties(shape, rootElement, { extensionElements: rootExtensionElements });
-    }
+        modeling.updateModdleProperties(shape, rootElement, { extensionElements: rootExtensionElements });
+      }
 
-    // (2) remove existing form definition
-    let values = extensionElements.get('values').filter((element) => {
-      return element !== oldFormDefinition;
-    });
+      // (2) remove existing form definition
+      let values = extensionElements.get('values').filter((element) => {
+        return element !== oldFormDefinition;
+      });
 
-    // (3) create new form definition
-    const formId = createFormId();
+      // (3) create new form definition
+      const formId = createFormId();
 
-    const newFormDefinition = createFormDefinition({ formKey: createFormKey(formId) }, extensionElements, bpmnFactory);
+      const newFormDefinition = createFormDefinition({ formKey: createFormKey(formId) }, extensionElements, bpmnFactory);
 
-    values = [
-      ...values,
-      newFormDefinition
-    ];
+      values = [
+        ...values,
+        newFormDefinition
+      ];
 
-    modeling.updateModdleProperties(shape, extensionElements, {
-      values
-    });
+      modeling.updateModdleProperties(shape, extensionElements, {
+        values
+      });
 
-    // (4) create new user task form
-    const userTaskForm = createUserTaskForm({
-      id: formId,
-      body: oldUserTaskForm ? oldUserTaskForm.get('body') : ''
-    }, rootExtensionElements, bpmnFactory);
+      // (4) create new user task form
+      const userTaskForm = createUserTaskForm({
+        id: formId,
+        body: oldUserTaskForm ? oldUserTaskForm.get('body') : ''
+      }, rootExtensionElements, bpmnFactory);
 
-    modeling.updateModdleProperties(shape, rootExtensionElements, {
-      values: [
-        ...(rootExtensionElements.get('values') || []),
-        userTaskForm
-      ]
-    });
-  }, true);
+      modeling.updateModdleProperties(shape, rootExtensionElements, {
+        values: [
+          ...(rootExtensionElements.get('values') || []),
+          userTaskForm
+        ]
+      });
+    }, true);
 
+  }
 }
 
 FormDefinitionBehavior.$inject = [
@@ -125,8 +122,6 @@ FormDefinitionBehavior.$inject = [
   'eventBus',
   'modeling'
 ];
-
-inherits(FormDefinitionBehavior, CommandInterceptor);
 
 
 // helpers //////////////

--- a/lib/camunda-cloud/features/modeling/behavior/FormDefinitionBehavior.js
+++ b/lib/camunda-cloud/features/modeling/behavior/FormDefinitionBehavior.js
@@ -11,11 +11,6 @@ import {
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  remove as collectionRemove,
-  add as collectionAdd
-} from 'diagram-js/lib/util/Collections';
-
-import {
   createFormDefinition,
   createFormId,
   createFormKey,
@@ -28,15 +23,14 @@ import {
 /**
  * Zeebe specific form definition behavior.
  */
-export default function FormDefinitionBehavior(
-    eventBus, bpmnFactory) {
+export default function FormDefinitionBehavior(bpmnFactory, eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
   /**
    * ensures a zeebe:userTaskForm is cleaned up when user task got removed
    */
-  this.executed('shape.delete', function(context) {
+  this.postExecute('shape.delete', function(context) {
     const {
       shape,
       oldParent
@@ -46,39 +40,24 @@ export default function FormDefinitionBehavior(
 
     const userTaskForm = getUserTaskForm(shape, rootElement);
 
-    const rootExtensionElements = rootElement.get('extensionElements');
-
     if (!is(shape, 'bpmn:UserTask') || !userTaskForm) {
       return;
     }
 
-    collectionRemove(rootExtensionElements.get('values'), userTaskForm);
-
-    context.removedUserTaskForm = userTaskForm;
-  }, true);
-
-  this.revert('shape.delete', function(context) {
-    const {
-      removedUserTaskForm,
-      oldParent
-    } = context;
-
-    const rootElement = getRootElement(oldParent);
-
     const rootExtensionElements = rootElement.get('extensionElements');
 
-    if (!removedUserTaskForm) {
-      return;
-    }
+    const values = rootExtensionElements.get('values').filter((element) => {
+      return element !== userTaskForm;
+    });
 
-    collectionAdd(rootExtensionElements.get('values'), removedUserTaskForm);
+    modeling.updateModdleProperties(shape, rootExtensionElements, { values });
   }, true);
 
 
   /**
    * create fresh new copied form definition + user task form
    */
-  this.executed('shape.create', function(context) {
+  this.postExecute('shape.create', function(context) {
     const {
       shape,
     } = context;
@@ -101,82 +80,50 @@ export default function FormDefinitionBehavior(
 
     // (1) ensure extension elements in root
     if (!rootExtensionElements) {
+      rootExtensionElements = elementHelper.createElement('bpmn:ExtensionElements', { values: [] }, rootElement, bpmnFactory);
 
-      rootExtensionElements = elementHelper.createElement(
-        'bpmn:ExtensionElements',
-        { values: [] },
-        rootElement,
-        bpmnFactory
-      );
-
-      rootElement.set('extensionElements', rootExtensionElements);
+      modeling.updateModdleProperties(shape, rootElement, { extensionElements: rootExtensionElements });
     }
 
     // (2) remove existing form definition
-    context.oldFormDefinition = oldFormDefinition;
-
-    collectionRemove(extensionElements.get('values'), oldFormDefinition);
-
-    const formId = createFormId();
+    let values = extensionElements.get('values').filter((element) => {
+      return element !== oldFormDefinition;
+    });
 
     // (3) create new form definition
-    const formDefinition = createFormDefinition(
-      {
-        formKey: createFormKey(formId)
-      },
-      extensionElements,
-      bpmnFactory
-    );
+    const formId = createFormId();
 
-    collectionAdd(extensionElements.get('values'), formDefinition);
+    const newFormDefinition = createFormDefinition({ formKey: createFormKey(formId) }, extensionElements, bpmnFactory);
+
+    values = [
+      ...values,
+      newFormDefinition
+    ];
+
+    modeling.updateModdleProperties(shape, extensionElements, {
+      values
+    });
 
     // (4) create new user task form
-    const userTaskForm = createUserTaskForm(
-      {
-        id: formId,
-        body: oldUserTaskForm ? oldUserTaskForm.get('body') : ''
-      },
-      rootExtensionElements,
-      bpmnFactory
-    );
+    const userTaskForm = createUserTaskForm({
+      id: formId,
+      body: oldUserTaskForm ? oldUserTaskForm.get('body') : ''
+    }, rootExtensionElements, bpmnFactory);
 
-    collectionAdd(rootExtensionElements.get('values'), userTaskForm);
-  }, true);
-
-  this.revert('shape.create', function(context) {
-    const {
-      shape,
-      oldFormDefinition
-    } = context;
-
-    const businessObject = getBusinessObject(shape);
-
-    const extensionElements = businessObject.get('extensionElements');
-
-    const formDefinition = getFormDefinition(shape);
-
-    const userTaskForm = getUserTaskForm(shape);
-
-    const rootElement = getRootElement(shape);
-
-    const rootExtensionElements = rootElement.get('extensionElements');
-
-    if (!is(shape, 'bpmn:UserTask') || !userTaskForm) {
-      return;
-    }
-
-    // we need to cover the old form definition to make <redo> possible
-    collectionRemove(extensionElements.get('values'), formDefinition);
-    collectionAdd(extensionElements.get('values'), oldFormDefinition);
-
-    collectionRemove(rootExtensionElements.get('values'), userTaskForm);
+    modeling.updateModdleProperties(shape, rootExtensionElements, {
+      values: [
+        ...(rootExtensionElements.get('values') || []),
+        userTaskForm
+      ]
+    });
   }, true);
 
 }
 
 FormDefinitionBehavior.$inject = [
+  'bpmnFactory',
   'eventBus',
-  'bpmnFactory'
+  'modeling'
 ];
 
 inherits(FormDefinitionBehavior, CommandInterceptor);

--- a/lib/camunda-cloud/features/modeling/behavior/UpdatePropagateAllChildVariablesBehavior.js
+++ b/lib/camunda-cloud/features/modeling/behavior/UpdatePropagateAllChildVariablesBehavior.js
@@ -29,8 +29,7 @@ const HIGH_PRIORITY = 15000;
  * It will ensure that the propagateAllChildVariables attribute on calledElement
  * extensionElements for callActivities is always consistent with outputParameter mappings
  */
-export default function UpdatePropagateAllChildVariablesBehavior(
-    eventBus) {
+export default function UpdatePropagateAllChildVariablesBehavior(eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
@@ -39,7 +38,7 @@ export default function UpdatePropagateAllChildVariablesBehavior(
    * remove outputParameters from zeebe:IoMapping when setting propgateAlLChildVariables
    * to true in the proeprties panel
    */
-  this.executed('properties-panel.update-businessobject' , HIGH_PRIORITY, function(context) {
+  this.postExecute('properties-panel.update-businessobject' , HIGH_PRIORITY, function(context) {
     const {
       element,
       properties
@@ -63,42 +62,25 @@ export default function UpdatePropagateAllChildVariablesBehavior(
       return;
     }
 
-    // (3) Store old outputParameters and remove them
-    context.oldOutputParameters = outputParameters;
-
+    // (3) remove old outputParameters
     const inputOutput = getInputOutput(element);
-    inputOutput.outputParameters = [];
 
-    // (4) if we also have no inputParameters, store IOMapping and remove it
+    modeling.updateModdleProperties(element, inputOutput, {
+      'zeebe:outputParameters': []
+    });
+
+    // (4) if we also have no inputParameters, remove IOMapping
     if (!inputParameters || inputParameters.length === 0) {
-      const extensionElements = getBusinessObject(element).extensionElements;
-      context.oldExtensionElements = extensionElements.values;
+      const businessObject = getBusinessObject(element),
+            extensionElements = businessObject.get('extensionElements');
 
-      extensionElements.values = extensionElements.values.filter(ele => ele.$type !== 'zeebe:IoMapping');
-    }
-  }, true);
+      const values = extensionElements.get('values').filter((element) => {
+        return !is(element, 'zeebe:IoMapping');
+      });
 
-  // Revert behavior when toggling propagateAllChildVariables //////////////////
-  this.reverted('properties-panel.update-businessobject', HIGH_PRIORITY, function(context) {
-    const {
-      element,
-      oldOutputParameters,
-      oldExtensionElements
-    } = context;
-
-    // (1) Only intercept the revert, if the behavior became active
-    if (oldOutputParameters) {
-
-      // (2) If we removed the IOMapping, bring it back first
-      if (oldExtensionElements) {
-        const extensionElements = getBusinessObject(element).extensionElements;
-
-        extensionElements.values = oldExtensionElements;
-      }
-
-      // (3) Bring back the outputParameters
-      const inputOutput = getInputOutput(element);
-      inputOutput.outputParameters = oldOutputParameters;
+      modeling.updateModdleProperties(element, extensionElements, {
+        values
+      });
     }
   }, true);
 
@@ -107,7 +89,7 @@ export default function UpdatePropagateAllChildVariablesBehavior(
   /**
    * un-toggle propgateAlLChildVariables when adding output parameters
    */
-  this.executed('properties-panel.update-businessobject-list' , HIGH_PRIORITY, function(context) {
+  this.postExecute('properties-panel.update-businessobject-list' , HIGH_PRIORITY, function(context) {
     const {
       element,
       objectsToAdd
@@ -125,36 +107,20 @@ export default function UpdatePropagateAllChildVariablesBehavior(
     }
 
     // (2) Store the old propAllChildVariables value and update it then
-    const bo = getBusinessObject(element),
-          calledElement = getCalledElement(bo);
+    const businessObject = getBusinessObject(element),
+          calledElement = getCalledElement(businessObject);
 
-    context.oldPropagateAllChildVariables = true;
-
-    calledElement.propagateAllChildVariables = false;
+    modeling.updateModdleProperties(element, calledElement, {
+      'zeebe:propagateAllChildVariables': false
+    });
   }, true);
-
-  // Revert behavior when adding outputParmaeters ////////////////////////////////////
-  this.reverted('properties-panel.update-businessobject-list' , HIGH_PRIORITY, function(context) {
-    const {
-      element,
-      oldPropagateAllChildVariables
-    } = context;
-
-    // (1) Only intercept the revert, if the behavior became active
-    if (oldPropagateAllChildVariables) {
-      const bo = getBusinessObject(element),
-            calledElement = getCalledElement(bo);
-
-      calledElement.propagateAllChildVariables = oldPropagateAllChildVariables;
-    }
-  }, true);
-
 
 }
 
 
 UpdatePropagateAllChildVariablesBehavior.$inject = [
-  'eventBus'
+  'eventBus',
+  'modeling'
 ];
 
 

--- a/lib/camunda-cloud/features/modeling/behavior/UpdatePropagateAllChildVariablesBehavior.js
+++ b/lib/camunda-cloud/features/modeling/behavior/UpdatePropagateAllChildVariablesBehavior.js
@@ -1,10 +1,7 @@
 import {
-  getBusinessObject
+  getBusinessObject,
+  is
 } from 'bpmn-js/lib/util/ModelUtil';
-
-import inherits from 'inherits';
-
-import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   getCalledElement,
@@ -14,114 +11,99 @@ import {
 import {
   getInputParameters,
   getOutputParameters,
-  getInputOutput
+  getIoMapping
 } from '../../../helper/InputOutputHelper';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-const HIGH_PRIORITY = 15000;
+const HIGH_PRIORITY = 5000;
 
 
 /**
- * UpdatePropagateAllChildVariablesBehavior reacts to either (1) toggling on propagateAllChildVariables
- * when there are outputParameters present or (2) to adding outputParameters when
- * propagateAllChildVariables is set to true.
- * It will ensure that the propagateAllChildVariables attribute on calledElement
- * extensionElements for callActivities is always consistent with outputParameter mappings
+ * Zeebe BPMN behavior for updating zeebe:propagateAllChildVariables.
  */
-export default function UpdatePropagateAllChildVariablesBehavior(eventBus, modeling) {
+export default class UpdatePropagateAllChildVariablesBehavior extends CommandInterceptor {
+  constructor(eventBus, modeling) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
+    /**
+     * Remove zeebe:OutputParameters when zeebe:propagateAllChildVariables is set to true.
+     */
+    this.postExecute('properties-panel.update-businessobject' , HIGH_PRIORITY, function(context) {
+      const {
+        element,
+        properties
+      } = context;
 
-  // Behavior when toggling propagateAllChildVariables /////////////////////////
-  /**
-   * remove outputParameters from zeebe:IoMapping when setting propgateAlLChildVariables
-   * to true in the proeprties panel
-   */
-  this.postExecute('properties-panel.update-businessobject' , HIGH_PRIORITY, function(context) {
-    const {
-      element,
-      properties
-    } = context;
+      if (
+        !is(element, 'bpmn:CallActivity')
+        || !properties
+        || !!properties.propagateAllChildVariables === false
+      ) {
+        return;
+      }
 
-    // (1) Don't execute this behavior if we are not in a call activity or not
-    // have properties to update or not update the propagateAllChildVariables
-    // to false
-    if (!is(element, 'bpmn:CallActivity') ||
-        !properties ||
-        !!properties.propagateAllChildVariables === false) {
-      return;
-    }
+      const inputParameters = getInputParameters(element),
+            outputParameters = getOutputParameters(element);
 
-    // (2) Check whether we have outputParameters
-    const outputParameters = getOutputParameters(element),
-          inputParameters = getInputParameters(element);
+      if (!outputParameters || !outputParameters.length) {
+        return;
+      }
 
-    if (!outputParameters ||
-      outputParameters.length === 0) {
-      return;
-    }
+      const ioMapping = getIoMapping(element);
 
-    // (3) remove old outputParameters
-    const inputOutput = getInputOutput(element);
+      modeling.updateModdleProperties(element, ioMapping, {
+        'zeebe:outputParameters': []
+      });
 
-    modeling.updateModdleProperties(element, inputOutput, {
-      'zeebe:outputParameters': []
-    });
+      if (!inputParameters || !inputParameters.length) {
+        const businessObject = getBusinessObject(element),
+              extensionElements = businessObject.get('extensionElements');
 
-    // (4) if we also have no inputParameters, remove IOMapping
-    if (!inputParameters || inputParameters.length === 0) {
+        const values = extensionElements.get('values').filter((element) => {
+          return !is(element, 'zeebe:IoMapping');
+        });
+
+        modeling.updateModdleProperties(element, extensionElements, {
+          values
+        });
+      }
+    }, true);
+
+
+    /**
+     * Set zeebe:propagateAllChildVariables to false on zeebe:Output added.
+     */
+    this.postExecute('properties-panel.update-businessobject-list' , HIGH_PRIORITY, function(context) {
+      const {
+        currentObject,
+        element,
+        objectsToAdd,
+        propertyName
+      } = context;
+
+      if (!is(element, 'bpmn:CallActivity')
+        || !is(currentObject, 'zeebe:IoMapping')
+        || (propertyName !== 'outputParameters' && propertyName !== 'zeebe:outputParameters')
+        || !objectsToAdd
+        || !objectsToAdd.length
+        || !objectsToAdd.find((object) => is(object, 'zeebe:Output'))
+        || !isPropagateAllChildVariables(element)) {
+        return;
+      }
+
       const businessObject = getBusinessObject(element),
-            extensionElements = businessObject.get('extensionElements');
+            calledElement = getCalledElement(businessObject);
 
-      const values = extensionElements.get('values').filter((element) => {
-        return !is(element, 'zeebe:IoMapping');
+      modeling.updateModdleProperties(element, calledElement, {
+        'zeebe:propagateAllChildVariables': false
       });
+    }, true);
 
-      modeling.updateModdleProperties(element, extensionElements, {
-        values
-      });
-    }
-  }, true);
-
-
-  // Behavior when adding outputParameters ////////////////////////////////////
-  /**
-   * un-toggle propgateAlLChildVariables when adding output parameters
-   */
-  this.postExecute('properties-panel.update-businessobject-list' , HIGH_PRIORITY, function(context) {
-    const {
-      element,
-      objectsToAdd
-    } = context;
-
-
-    // (1) Exit if we are not in a CallActivity, not adding an OutputParameter or not
-    // having set propagateAllChildVariables to false
-    if (!is(element, 'bpmn:CallActivity') ||
-     !objectsToAdd ||
-     objectsToAdd.length === 0 ||
-     objectsToAdd.filter(obj => is(obj, 'zeebe:Output')).length === 0 ||
-    isPropagateAllChildVariables(element) === false) {
-      return;
-    }
-
-    // (2) Store the old propAllChildVariables value and update it then
-    const businessObject = getBusinessObject(element),
-          calledElement = getCalledElement(businessObject);
-
-    modeling.updateModdleProperties(element, calledElement, {
-      'zeebe:propagateAllChildVariables': false
-    });
-  }, true);
-
+  }
 }
-
 
 UpdatePropagateAllChildVariablesBehavior.$inject = [
   'eventBus',
   'modeling'
 ];
-
-
-inherits(UpdatePropagateAllChildVariablesBehavior, CommandInterceptor);

--- a/lib/camunda-cloud/features/properties-provider/parts/implementation/InputOutput.js
+++ b/lib/camunda-cloud/features/properties-provider/parts/implementation/InputOutput.js
@@ -15,11 +15,12 @@ import entryFieldDescription from 'bpmn-js-properties-panel/lib/factory/EntryFie
 import {
   areOutputParametersSupported,
   areInputParametersSupported,
-  createIOMapping,
+  createIoMapping,
   createElement as createParameter,
-  determineParamGetFunc,
-  getInputOutput,
-  isInputOutputSupported
+  getIoMapping,
+  isInputOutputSupported,
+  getInputParameters,
+  getOutputParameters
 } from '../../../../helper/InputOutputHelper';
 
 import InputOutputParameter from './InputOutputParameter';
@@ -130,12 +131,12 @@ function getParametersHeadingEntry(element, bpmnFactory, options) {
     }
 
     // Get the IOMapping
-    let inputOutput = getInputOutput(element);
+    let inputOutput = getIoMapping(element);
 
     if (!inputOutput) {
       const parent = extensionElements;
 
-      inputOutput = createIOMapping(parent, bpmnFactory, {
+      inputOutput = createIoMapping(parent, bpmnFactory, {
         inputParameters: [],
         outputParameters: []
       });
@@ -190,7 +191,7 @@ function getParametersHeadingEntry(element, bpmnFactory, options) {
 function getIOMappingEntries(element, bpmnFactory, translate, options) {
 
   // Get the IOMapping and determine whether we are dealing with input or output parameters
-  const inputOutput = getInputOutput(element, false),
+  const inputOutput = getIoMapping(element),
         params = determineParamGetFunc(options.prop)(element, false);
 
   if (!params.length) {
@@ -256,5 +257,18 @@ function getIOMappingEntries(element, bpmnFactory, translate, options) {
 
       parameter.setOpen(false);
     });
+  }
+}
+
+
+// helpers //////////
+
+function determineParamGetFunc(property) {
+  if (property == 'inputParameters') {
+    return getInputParameters;
+  }
+
+  if (property == 'outputParameters') {
+    return getOutputParameters;
   }
 }

--- a/lib/camunda-cloud/features/rules/BpmnRules.js
+++ b/lib/camunda-cloud/features/rules/BpmnRules.js
@@ -22,7 +22,7 @@ import {
   getBoundaryAttachment as isBoundaryAttachment
 } from 'bpmn-js/lib/features/snapping/BpmnSnappingUtil';
 
-const HIGH_PRIORITY = 15000;
+const HIGH_PRIORITY = 5000;
 
 /**
  * Zeebe rule provider that allows to create boundary events with catch events

--- a/lib/camunda-cloud/helper/CalledElementHelper.js
+++ b/lib/camunda-cloud/helper/CalledElementHelper.js
@@ -1,70 +1,72 @@
-import {
-  has
-} from 'min-dash';
+import { has } from 'min-dash';
+
+import { getOutputParameters } from './InputOutputHelper';
+
+import { getExtensionElements } from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
 
 import {
-  getOutputParameters
-} from './InputOutputHelper';
-
-import {
-  getExtensionElements
-} from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
-
-import {
-  getBusinessObject
-} from 'bpmn-js/lib/util/ModelUtil';
-
-import {
+  getBusinessObject,
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
+
 /**
-  * Determine default value for propagateAllChildVariables attribute
-  * @param {Object} element representing a bpmn:CallActivity
-  *
-  * @returns {boolean}
-  */
-function determinePropAllChildVariablesDefault(element) {
+ * Get default value for zeebe:propagateAllChildVariables.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ *
+ * @returns {boolean}
+ */
+function getPropagateAllChildVariablesDefault(element) {
+  if (!is(element, 'bpmn:CallActivity')) {
+    return;
+  }
+
   const outputParameters = getOutputParameters(element);
 
   if (outputParameters) {
-    return (outputParameters.length > 0) ? false : true;
+    return !outputParameters.length;
   }
 }
 
 /**
-  * Get the 'zeebe:CalledElement' extension element for a given business Object
-  * @param {Object} bo businessObject
-  *
-  * @returns {Object} the calledElement Moddle Object or undefined if zeebe:CalledElement does not exist
-  */
+ * Get zeebe:CalledElement of an element.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ *
+ * @returns {ModdleElement}
+ */
 export function getCalledElement(element) {
   const calledElements = getCalledElements(element);
-  return calledElements[0];
+
+  return calledElements[ 0 ];
 }
 
 export function getCalledElements(element) {
-  const bo = getBusinessObject(element);
-  const extElements = getExtensionElements(bo, 'zeebe:CalledElement');
-  return extElements;
+  const businessObject = getBusinessObject(element);
+
+  return getExtensionElements(businessObject, 'zeebe:CalledElement');
 }
 
 /**
-  * Check whether the propagateAllChildVariables attribute is set on an element.
-  * Note that a default logic will be determine if it is not explicitly set.
-  * @param {Object} element
-  *
-  * @returns {boolean}
-  */
+ * Check whether zeebe:propagateAllChildVariables is set on an element.
+ * Fall back to default if zeebe:propagateAllChildVariables not set.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ *
+ * @returns {boolean}
+ */
 export function isPropagateAllChildVariables(element) {
   if (!is(element, 'bpmn:CallActivity')) {
-    return undefined;
+    return;
   }
 
-  const bo = getBusinessObject(element),
-        calledElement = getCalledElement(bo);
+  const businessObject = getBusinessObject(element),
+        calledElement = getCalledElement(businessObject);
 
-  return calledElement && has(calledElement, 'propagateAllChildVariables') ?
-    calledElement.get('propagateAllChildVariables') :
-    determinePropAllChildVariablesDefault(element);
+  if (calledElement && has(calledElement, 'propagateAllChildVariables')) {
+    return calledElement.get('propagateAllChildVariables');
+  } else {
+    return getPropagateAllChildVariablesDefault(element);
+  }
 }

--- a/lib/camunda-cloud/helper/FormsHelper.js
+++ b/lib/camunda-cloud/helper/FormsHelper.js
@@ -1,6 +1,4 @@
-import {
-  getExtensionElements
-} from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+import { getExtensionElements } from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
 
 import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
 
@@ -9,47 +7,12 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import {
-  nextId
-} from 'bpmn-js-properties-panel/lib/Utils';
+import { nextId } from 'bpmn-js-properties-panel/lib/Utils';
 
-import {
-  find
-} from 'min-dash';
+import { find } from 'min-dash';
 
-const USER_TASK_FORM_PREFIX = 'userTaskForm_';
+const USER_TASK_FORM_PREFIX = 'UserTaskForm_';
 
-
-export function getUserTaskForm(element, parent) {
-
-  const rootElement = parent || getRootElement(element);
-
-  // (1) get form definition from user task
-  const formDefinition = getFormDefinition(element);
-
-  if (!formDefinition) {
-    return;
-  }
-
-  const formKey = formDefinition.get('formKey');
-
-  // (2) retrieve user task form via form key
-  const userTaskForm = findUserTaskForm(formKey, rootElement);
-
-  return userTaskForm;
-}
-
-export function getFormDefinition(element) {
-  const businessObject = getBusinessObject(element);
-
-  const formDefinitions = getExtensionElements(businessObject, 'zeebe:FormDefinition');
-
-  return formDefinitions[0];
-}
-
-export function createFormKey(formId) {
-  return 'camunda-forms:bpmn:' + formId;
-}
 
 export function createFormDefinition(properties, extensionElements, bpmnFactory) {
   return elementHelper.createElement(
@@ -58,6 +21,14 @@ export function createFormDefinition(properties, extensionElements, bpmnFactory)
     extensionElements,
     bpmnFactory
   );
+}
+
+export function createFormId() {
+  return nextId(USER_TASK_FORM_PREFIX);
+}
+
+export function createFormKey(formId) {
+  return `camunda-forms:bpmn:${ formId }`;
 }
 
 export function createUserTaskForm(properties, extensionElements, bpmnFactory) {
@@ -69,19 +40,22 @@ export function createUserTaskForm(properties, extensionElements, bpmnFactory) {
   );
 }
 
-export function createFormId() {
-  return nextId(USER_TASK_FORM_PREFIX);
+function findUserTaskForm(formKey, rootElement) {
+  const userTaskForms = getExtensionElements(rootElement, 'zeebe:UserTaskForm');
+
+  return find(userTaskForms, function(userTaskForm) {
+    const id = userTaskForm.get('zeebe:id');
+
+    return createFormKey(id) === formKey;
+  });
 }
 
+export function getFormDefinition(element) {
+  const businessObject = getBusinessObject(element);
 
-// helpers /////////////////////
+  const formDefinitions = getExtensionElements(businessObject, 'zeebe:FormDefinition');
 
-function findUserTaskForm(formKey, rootElement) {
-  const forms = getExtensionElements(rootElement, 'zeebe:UserTaskForm');
-
-  return find(forms, function(userTaskForm) {
-    return createFormKey(userTaskForm.id) === formKey;
-  });
+  return formDefinitions[ 0 ];
 }
 
 function getRootElement(element) {
@@ -93,4 +67,18 @@ function getRootElement(element) {
   }
 
   return parent;
+}
+
+export function getUserTaskForm(element, parent) {
+  const rootElement = parent || getRootElement(element);
+
+  const formDefinition = getFormDefinition(element);
+
+  if (!formDefinition) {
+    return;
+  }
+
+  const formKey = formDefinition.get('zeebe:formKey');
+
+  return findUserTaskForm(formKey, rootElement);
 }

--- a/lib/camunda-cloud/helper/InputOutputHelper.js
+++ b/lib/camunda-cloud/helper/InputOutputHelper.js
@@ -1,132 +1,135 @@
 import {
-  getBusinessObject
+  getBusinessObject,
+  is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import {
-  isAny
-} from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
-
-import {
-  isZeebeServiceTask
-} from './ZeebeServiceTaskHelper';
-
-import extensionElementsHelper from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
 
 import elementHelper from 'bpmn-js-properties-panel/lib/helper/ElementHelper';
 
-
-function getElements(bo, type, prop) {
-  const elems = extensionElementsHelper.getExtensionElements(bo, type);
-  return !prop ? elems : (elems[0] || {})[prop] || [];
-}
-
-function getParameters(element, prop) {
-  const inputOutput = getInputOutput(element);
-  return (inputOutput && inputOutput.get(prop)) || [];
-}
-
-/**
-   * Get a inputOutput from the business object
-   *
-   * @param {djs.model.Base} element
-   *
-   * @return {ModdleElement} the inputOutput object
-   */
-export function getInputOutput(element) {
-  const bo = getBusinessObject(element);
-  return (getElements(bo, 'zeebe:IoMapping') || [])[0];
-}
+import { isZeebeServiceTask } from './ZeebeServiceTaskHelper';
 
 
 /**
-   * Return all input parameters existing in the business object, and
-   * an empty array if none exist.
-   *
-   * @param  {djs.model.Base} element
-   *
-   * @return {Array} a list of input parameter objects
-   */
+ * Get zeebe:IoMapping from an element.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ *
+ * @return {ModdleElement}
+ */
+export function getIoMapping(element) {
+  const businessObject = getBusinessObject(element);
+
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return;
+  }
+
+  return extensionElements.get('values').find((value) => {
+    return is(value, 'zeebe:IoMapping');
+  });
+}
+
+/**
+ * Get zeebe:InputParameters from an element.
+ *
+ * @param  {djs.model.Base|ModdleElement} element
+ *
+ * @return {Array<ModdleElement>}
+ */
 export function getInputParameters(element) {
-  return getParameters.apply(this, [ element, 'inputParameters' ]);
+  const ioMapping = getIoMapping(element);
+
+  if (ioMapping) {
+    return ioMapping.get('zeebe:inputParameters');
+  }
+
+  return [];
 }
 
 /**
-   * Return all output parameters existing in the business object, and
-   * an empty array if none exist.
-   *
-   * @param  {djs.model.Base} element
-   *
-   * @return {Array} a list of output parameter objects
-   */
+ * Get zeebe:OutputParameters from an element.
+ *
+ * @param  {djs.model.Base|ModdleElement} element
+ *
+ * @return {Array<ModdleElement>}
+ */
 export function getOutputParameters(element) {
-  return getParameters.apply(this, [ element, 'outputParameters' ]);
+  const ioMapping = getIoMapping(element);
+
+  if (ioMapping) {
+    return ioMapping.get('zeebe:outputParameters');
+  }
+
+  return [];
 }
 
 /**
-   * Get a input parameter from the business object at given index
-   *
-   * @param {djs.model.Base} element
-   * @param {number} idx
-   *
-   * @return {ModdleElement} input parameter
-   */
-export function getInputParameter(element, idx) {
-  return getInputParameters(element)[idx];
+ * Get zeebe:Input at index.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ * @param {number} index
+ *
+ * @return {ModdleElement}
+ */
+export function getInputParameter(element, index) {
+  return getInputParameters(element)[ index ];
 }
 
 /**
-   * Get a output parameter from the business object at given index
-   *
-   * @param {djs.model.Base} element
-   * @param {number} idx
-   *
-   * @return {ModdleElement} output parameter
-   */
-export function getOutputParameter(element, idx) {
-  return getOutputParameters(element)[idx];
+ * Get zeebe:Output at index.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ * @param {number} index
+ *
+ * @return {ModdleElement}
+ */
+export function getOutputParameter(element, index) {
+  return getOutputParameters(element)[ index ];
 }
 
 /**
-   * Returns 'true' if the given element supports inputOutput
-   *
-   * @param {djs.model.Base} element
-   *
-   * @return {boolean} a boolean value
-   */
+ * Check whether element supports zeebe:Input or zeebe:Output.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ *
+ * @return {boolean}
+ */
 export function isInputOutputSupported(element) {
-  return areOutputParametersSupported(element) || areInputParametersSupported(element);
+  return areInputParametersSupported(element) || areOutputParametersSupported(element);
 }
 
 /**
-   * Returns 'true' if the given element supports input parameters
-   *
-   * @param {djs.model.Base} element
-   *
-   * @return {boolean} a boolean value
-   */
+ * Check whether element supports zeebe:Input.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ *
+ * @return {boolean}
+ */
 export function areInputParametersSupported(element) {
   return isAny(element, [
-    'bpmn:UserTask',
+    'bpmn:CallActivity',
     'bpmn:SubProcess',
-    'bpmn:CallActivity'
+    'bpmn:UserTask'
   ]) || isZeebeServiceTask(element);
 }
 
 /**
-   * Returns 'true' if the given element supports output parameters
-   *
-   * @param {djs.model.Base} element
-   *
-   * @return {boolean} a boolean value
-   */
+ * Check whether element supports zeebe:Output.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ *
+ * @return {boolean}
+ */
 export function areOutputParametersSupported(element) {
   return isAny(element, [
-    'zeebe:ZeebeServiceTask',
-    'bpmn:UserTask',
-    'bpmn:SubProcess',
-    'bpmn:ReceiveTask',
     'bpmn:CallActivity',
-    'bpmn:Event'
+    'bpmn:Event',
+    'bpmn:ReceiveTask',
+    'bpmn:SubProcess',
+    'bpmn:UserTask',
+    'zeebe:ZeebeServiceTask'
   ]);
 }
 
@@ -134,23 +137,6 @@ export function createElement(type, parent, factory, properties) {
   return elementHelper.createElement(type, properties, parent, factory);
 }
 
-export function createIOMapping(parent, bpmnFactory, properties) {
+export function createIoMapping(parent, bpmnFactory, properties) {
   return createElement('zeebe:IoMapping', parent, bpmnFactory, properties);
-}
-
-/**
- * Get getter function for IOMapping parameters according to provided property name
- *
- * @param {string} property
- *
- * @returns {Function} Getter function for the IOMapping parameters according to provided property name
- */
-export function determineParamGetFunc(property) {
-  if (property == 'inputParameters') {
-    return getInputParameters;
-  }
-
-  if (property == 'outputParameters') {
-    return getOutputParameters;
-  }
 }

--- a/lib/camunda-platform/features/modeling/behavior/DeleteErrorEventDefinitionBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/DeleteErrorEventDefinitionBehavior.js
@@ -1,5 +1,3 @@
-import inherits from 'inherits';
-
 import {
   getBusinessObject,
   is
@@ -11,18 +9,19 @@ const HIGH_PRIORITY = 5000;
 
 
 /**
- * Camunda BPMN specific `camunda:errorEventDefinition` behavior.
- *
- * When `camunda:type` is set to something different than `external`
- * on an element, then `camunda:errorEventDefinition` extension elements
- * shall be removed.
+ * Camunda BPMN specific camunda:ErrorEventDefinition behavior.
  */
-export default function DeleteErrorEventDefinitionBehavior(eventBus, modeling) {
+export default class DeleteErrorEventDefinitionBehavior extends CommandInterceptor {
+  constructor(eventBus, modeling) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
-
-  this.postExecute([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
-    HIGH_PRIORITY, function(context) {
+    /**
+     * Remove camunda:ErrorEventDefinitions on camunda:type set to external.
+     */
+    this.postExecute([
+      'element.updateProperties',
+      'properties-panel.update-businessobject'
+    ], HIGH_PRIORITY, function(context) {
       const {
         element,
         oldProperties,
@@ -30,37 +29,30 @@ export default function DeleteErrorEventDefinitionBehavior(eventBus, modeling) {
       } = context;
 
       const businessObject = getBusinessObject(element),
-            extensionElements = businessObject.extensionElements;
+            extensionElements = businessObject.get('extensionElements');
 
-      // (1) Check whether behavior is suitable
-      if (
-        is(element, 'camunda:ExternalCapable') &&
-        extensionElements &&
-        externalTypeChanged(oldProperties, properties)
-      ) {
+      if (is(element, 'camunda:ExternalCapable')
+        && extensionElements
+        && externalTypeChanged(oldProperties, properties)) {
 
-        // (2) delete camunda:ErrorEventDefinition elements
         const values = extensionElements.get('values').filter((element) => {
           return !is(element, 'camunda:ErrorEventDefinition');
         });
 
         modeling.updateModdleProperties(element, extensionElements, { values });
       }
-
     }, true);
 
+  }
 }
-
 
 DeleteErrorEventDefinitionBehavior.$inject = [
   'eventBus',
   'modeling'
 ];
 
-inherits(DeleteErrorEventDefinitionBehavior, CommandInterceptor);
 
-
-// helper //////////////////
+// helpers //////////
 
 function externalTypeChanged(oldProperties, updatesProperties) {
   const {

--- a/lib/camunda-platform/features/modeling/behavior/DeleteErrorEventDefinitionBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/DeleteErrorEventDefinitionBehavior.js
@@ -17,11 +17,11 @@ const HIGH_PRIORITY = 5000;
  * on an element, then `camunda:errorEventDefinition` extension elements
  * shall be removed.
  */
-export default function DeleteErrorEventDefinitionBehavior(eventBus) {
+export default function DeleteErrorEventDefinitionBehavior(eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
-  this.executed([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
+  this.postExecute([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
     HIGH_PRIORITY, function(context) {
       const {
         element,
@@ -39,37 +39,22 @@ export default function DeleteErrorEventDefinitionBehavior(eventBus) {
         externalTypeChanged(oldProperties, properties)
       ) {
 
-        // (2) Delete camunda:ErrorEventDefinition elements and save them for revert
-        context.deletedErrorEventDefinitions = extensionElements.values;
+        // (2) delete camunda:ErrorEventDefinition elements
+        const values = extensionElements.get('values').filter((element) => {
+          return !is(element, 'camunda:ErrorEventDefinition');
+        });
 
-        extensionElements.values = extensionElements.values.filter(
-          element => !is(element, 'camunda:ErrorEventDefinition')
-        );
+        modeling.updateModdleProperties(element, extensionElements, { values });
       }
 
     }, true);
 
-  this.reverted([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
-    HIGH_PRIORITY, function({ context }) {
-      const {
-        element,
-        deletedErrorEventDefinitions: oldExtensionElements
-      } = context;
-
-      const businessObject = getBusinessObject(element);
-
-      // Only intercept the revert, if the behavior became active
-      if (oldExtensionElements) {
-        const extensionElements = businessObject.extensionElements;
-
-        extensionElements.values = oldExtensionElements;
-      }
-    });
 }
 
 
 DeleteErrorEventDefinitionBehavior.$inject = [
-  'eventBus'
+  'eventBus',
+  'modeling'
 ];
 
 inherits(DeleteErrorEventDefinitionBehavior, CommandInterceptor);

--- a/lib/camunda-platform/features/modeling/behavior/DeleteRetryTimeCycleBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/DeleteRetryTimeCycleBehavior.js
@@ -1,32 +1,27 @@
-import inherits from 'inherits';
-
 import {
   getBusinessObject,
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import {
-  find
-} from 'min-dash';
-
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-const HIGH_PRIORITY = 15000;
+const HIGH_PRIORITY = 5000;
 
 
 /**
- * Camunda BPMN specific `camunda:FailedJobRetryTimeCycle` behavior.
- *
- * When `camunda:asyncAfter` or `camunda:asyncBefore` are set to false
- * on an element, then `camunda:FailedJobRetryTimeCycle` shall be removed. This ensures
- * that the BPMN diagram XML reflects the behavior of Camunda Platform engine.
+ * Camunda BPMN specific camunda:FailedJobRetryTimeCycle behavior.
  */
-export default function DeleteRetryTimeCycleBehavior(eventBus, modeling) {
+export default class DeleteRetryTimeCycleBehavior extends CommandInterceptor {
+  constructor(eventBus, modeling) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
-
-  this.postExecute([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
-    HIGH_PRIORITY, function(context) {
+    /**
+     * Remove camunda:FailedJobRetryTimeCycle if camunda:asyncAfter or camunda:asyncBefore is set to false.
+     */
+    this.postExecute([
+      'element.updateProperties',
+      'properties-panel.update-businessobject'
+    ], HIGH_PRIORITY, function(context) {
       const {
         element,
         properties
@@ -35,80 +30,55 @@ export default function DeleteRetryTimeCycleBehavior(eventBus, modeling) {
       const businessObject = getBusinessObject(element),
             extensionElements = businessObject.extensionElements;
 
-      // (1.1) Execute if...
-      if (is(element, 'camunda:AsyncCapable') && // ...asyncCapable
-        properties && // ...properties updated
-        (properties['camunda:asyncBefore'] === false || // ...update async (1)
-          properties['camunda:asyncAfter'] === false) && // ...update async (2)
-        (extensionElements && extensionElements.values.length) && // ...we have extensionElements
-        (extensionElements.values.find(ele => is(ele, 'camunda:FailedJobRetryTimeCycle'))) && // ...we have retryTimeCycle
-        !getTimerEventDefinition(element) // ...we don't have a TimerEventDefinition
+      if (
+        !is(element, 'camunda:AsyncCapable')
+        || (properties[ 'camunda:asyncBefore' ] !== false && properties[ 'camunda:asyncAfter' ] !== false)
+        || !extensionElements
+        || !extensionElements.get('values').length
+        || !extensionElements.get('values').find((value) => is(value, 'camunda:FailedJobRetryTimeCycle'))
+        || getTimerEventDefinition(element)
+        || isAsyncBefore(businessObject)
+        || isAsyncAfter(businessObject)
       ) {
-
-        // (1.2) ... but don't execute if one async is still true
-        if (isAsyncBefore(businessObject) || isAsyncAfter(businessObject)) {
-          return;
-        }
-
-        // (2) Delete the camunda:FailedJobRetryTimeCycle and save them for revert
-        context.deleteRetryCycleOldExtElements = extensionElements.values;
-
-        const values = extensionElements.get('values').filter((element) => {
-          return !is(element, 'camunda:FailedJobRetryTimeCycle');
-        });
-
-        modeling.updateModdleProperties(element, extensionElements, { values });
+        return;
       }
 
+      const values = extensionElements.get('values').filter((element) => {
+        return !is(element, 'camunda:FailedJobRetryTimeCycle');
+      });
+
+      modeling.updateModdleProperties(element, extensionElements, { values });
     }, true);
 
+  }
 }
-
 
 DeleteRetryTimeCycleBehavior.$inject = [
   'eventBus',
   'modeling'
 ];
 
-inherits(DeleteRetryTimeCycleBehavior, CommandInterceptor);
 
+// helpers //////////
 
-// helper //////////////////
-
-/**
- * Returns true if the attribute 'camunda:asyncBefore' is set
- * to true.
- *
- * @param  {ModdleElement} bo
- *
- * @return {boolean} a boolean value
- */
-function isAsyncBefore(bo) {
-  return !!(bo.get('camunda:asyncBefore') || bo.get('camunda:async'));
+function isAsyncBefore(businessObject) {
+  return !!(businessObject.get('camunda:asyncBefore') || businessObject.get('camunda:async'));
 }
 
-/**
- * Returns true if the attribute 'camunda:asyncAfter' is set
- * to true.
- *
- * @param  {ModdleElement} bo
- *
- * @return {boolean} a boolean value
- */
-function isAsyncAfter(bo) {
-  return !!bo.get('camunda:asyncAfter');
+function isAsyncAfter(businessObject) {
+  return !!businessObject.get('camunda:asyncAfter');
 }
 
 function getTimerEventDefinition(element) {
   return getEventDefinition(element, 'bpmn:TimerEventDefinition');
 }
 
-function getEventDefinition(element, eventType) {
+function getEventDefinition(element, type) {
   const businessObject = getBusinessObject(element);
 
   const eventDefinitions = businessObject.get('eventDefinitions') || [];
 
-  return find(eventDefinitions, function(definition) {
-    return is(definition, eventType);
+  return eventDefinitions.find((eventDefinition) => {
+    return is(eventDefinition, type);
   });
 }

--- a/lib/camunda-platform/features/modeling/behavior/DeleteRetryTimeCycleBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/DeleteRetryTimeCycleBehavior.js
@@ -21,11 +21,11 @@ const HIGH_PRIORITY = 15000;
  * on an element, then `camunda:FailedJobRetryTimeCycle` shall be removed. This ensures
  * that the BPMN diagram XML reflects the behavior of Camunda Platform engine.
  */
-export default function DeleteRetryTimeCycleBehavior(eventBus) {
+export default function DeleteRetryTimeCycleBehavior(eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
-  this.executed([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
+  this.postExecute([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
     HIGH_PRIORITY, function(context) {
       const {
         element,
@@ -53,33 +53,21 @@ export default function DeleteRetryTimeCycleBehavior(eventBus) {
         // (2) Delete the camunda:FailedJobRetryTimeCycle and save them for revert
         context.deleteRetryCycleOldExtElements = extensionElements.values;
 
-        extensionElements.values = extensionElements.values.filter(
-          ele => !is(ele, 'camunda:FailedJobRetryTimeCycle'));
+        const values = extensionElements.get('values').filter((element) => {
+          return !is(element, 'camunda:FailedJobRetryTimeCycle');
+        });
+
+        modeling.updateModdleProperties(element, extensionElements, { values });
       }
 
     }, true);
 
-  this.reverted([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
-    HIGH_PRIORITY, function({ context }) {
-      const {
-        element,
-        deleteRetryCycleOldExtElements: oldExtensionElements
-      } = context;
-
-      const businessObject = getBusinessObject(element);
-
-      // Only intercept the revert, if the behavior became active
-      if (oldExtensionElements) {
-        const extensionElements = businessObject.extensionElements;
-
-        extensionElements.values = oldExtensionElements;
-      }
-    });
 }
 
 
 DeleteRetryTimeCycleBehavior.$inject = [
-  'eventBus'
+  'eventBus',
+  'modeling'
 ];
 
 inherits(DeleteRetryTimeCycleBehavior, CommandInterceptor);

--- a/lib/camunda-platform/features/modeling/behavior/UpdateCamundaExclusiveBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateCamundaExclusiveBehavior.js
@@ -1,5 +1,3 @@
-import inherits from 'inherits';
-
 import {
   getBusinessObject,
   is
@@ -7,22 +5,23 @@ import {
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-const HIGH_PRIORITY = 15000;
+const HIGH_PRIORITY = 5000;
 
 
 /**
- * Camunda BPMN specific `camunda:exclusive` behavior.
- *
- * When `camunda:asyncAfter` or `camunda:asyncBefore` are set to false
- * on an element, then `camunda:exclusive` shall be set to true. This ensures
- * that the BPMN diagram XML reflects the behavior of Camunda Platform engine.
+ * Camunda BPMN specific camunda:exclusive behavior.
  */
-export default function UpdateCamundaExclusiveBehavior(eventBus) {
+export default class UpdateCamundaExclusiveBehavior extends CommandInterceptor {
+  constructor(eventBus) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
-
-  this.preExecute([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
-    HIGH_PRIORITY, function(context) {
+    /**
+     * Set camunda:exclusive to true on camunda:asyncBefore or camunda:asyncAfter set to false.
+     */
+    this.preExecute([
+      'element.updateProperties',
+      'properties-panel.update-businessobject'
+    ], HIGH_PRIORITY, function(context) {
       const {
         element,
         properties
@@ -30,70 +29,37 @@ export default function UpdateCamundaExclusiveBehavior(eventBus) {
 
       const businessObject = getBusinessObject(element);
 
-      // (1.1) Execute if...
-      if (is(element, 'camunda:AsyncCapable') && // ...asyncCapable
-          properties && // ...properties updated
-          (properties['camunda:asyncBefore'] === false || // ...update async before or (1)
-            properties['camunda:asyncAfter'] === false) && // ...update async after (2)
-          !isExclusive(businessObject) // ...is currently not exclusive
+      if (!is(element, 'camunda:AsyncCapable')
+        || (properties[ 'camunda:asyncBefore' ] !== false && properties[ 'camunda:asyncAfter' ] !== false)
+        || isExclusive(businessObject)
+        || (isAsyncAfter(businessObject) && properties[ 'camunda:asyncAfter' ] !== false)
+        || (isAsyncBefore(businessObject) && properties[ 'camunda:asyncBefore' ] !== false)
+        || (properties[ 'camunda:asyncBefore' ] === true || properties[ 'camunda:asyncAfter' ] === true)
       ) {
-
-        // (1.2) ...but don't execute if...
-        if ((isAsyncAfter(businessObject) && properties['camunda:asyncAfter'] !== false) || // ...asyncAfter will stay
-            (isAsyncBefore(businessObject) && properties['camunda:asyncBefore'] !== false) || // ...asyncBefore will stay
-            (properties['camunda:asyncBefore'] || properties['camunda:asyncAfter']) // one is set to true
-        ) {
-          return;
-        }
-
-        // (2) Update the context
-        properties['camunda:exclusive'] = true;
+        return;
       }
-    }, true);
-}
 
+      properties[ 'camunda:exclusive' ] = true;
+    }, true);
+
+  }
+}
 
 UpdateCamundaExclusiveBehavior.$inject = [
   'eventBus'
 ];
 
-inherits(UpdateCamundaExclusiveBehavior, CommandInterceptor);
 
+// helpers //////////
 
-// helper //////////////////
-
-/**
- * Returns true if the attribute 'camunda:asyncBefore' is set
- * to true.
- *
- * @param  {ModdleElement} bo
- *
- * @return {boolean} a boolean value
- */
-function isAsyncBefore(bo) {
-  return !!(bo.get('camunda:asyncBefore') || bo.get('camunda:async'));
+function isAsyncBefore(businessObject) {
+  return !!(businessObject.get('camunda:asyncBefore') || businessObject.get('camunda:async'));
 }
 
-/**
- * Returns true if the attribute 'camunda:asyncAfter' is set
- * to true.
- *
- * @param  {ModdleElement} bo
- *
- * @return {boolean} a boolean value
- */
-function isAsyncAfter(bo) {
-  return !!bo.get('camunda:asyncAfter');
+function isAsyncAfter(businessObject) {
+  return !!businessObject.get('camunda:asyncAfter');
 }
 
-/**
-* Returns true if the attribute 'camunda:exclusive' is set
-* to true.
-*
-* @param  {ModdleElement} bo
-*
-* @return {boolean} a boolean value
-*/
-function isExclusive(bo) {
-  return !!bo.get('camunda:exclusive');
+function isExclusive(businessObject) {
+  return !!businessObject.get('camunda:exclusive');
 }

--- a/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
@@ -1,88 +1,54 @@
-import inherits from 'inherits';
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  getBusinessObject,
-  is
-} from 'bpmn-js/lib/util/ModelUtil';
+  getInputOutput,
+  isInputOutputEmpty
+} from 'lib/camunda-platform/helper/InputOutputHelper';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 /**
- * Camunda BPMN specific `camunda:inputOutput` behavior.
+ * Camunda BPMN specific camunda:InputOutput behavior.
  */
-export default function UpdateInputOutputBehavior(eventBus, modeling) {
+export default class UpdateInputOutputBehavior extends CommandInterceptor {
+  constructor(eventBus, modeling) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
+    /**
+     * Remove empty camunda:InputOutput on update.
+     */
+    this.postExecute([
+      'element.updateProperties',
+      'element.updateModdleProperties',
+      'properties-panel.update-businessobject-list'
+    ], function(context) {
+      const {
+        element,
+        oldProperties,
+        propertyName
+      } = context;
 
-  this.postExecute([
-    'element.updateProperties',
-    'element.updateModdleProperties',
-    'properties-panel.update-businessobject-list'
-  ], function(context) {
-    const {
-      element,
-      oldProperties,
-      propertyName
-    } = context;
+      const businessObject = getBusinessObject(element),
+            inputOutput = getInputOutput(businessObject),
+            extensionElements = businessObject.get('extensionElements');
 
-    const businessObject = getBusinessObject(element);
-    const inputOutput = getInputOutput(businessObject);
-    const extensionElements = businessObject.get('extensionElements');
+      // do not remove newly added camunda:InputOutput
+      if (!oldProperties && propertyName === 'values') {
+        return;
+      }
 
-    // do not apply if inputOutput got recently added
-    if (!oldProperties && propertyName === 'values') {
-      return;
-    }
+      if (inputOutput && isInputOutputEmpty(inputOutput)) {
+        const values = extensionElements.get('values').filter(function(element) {
+          return element !== inputOutput;
+        });
 
-    // remove camunda:inputOutput if there are no input/output parameters anymore
-    if (inputOutput && isEmpty(inputOutput)) {
-      const filtered = extensionElements.values.filter(function(element) {
-        return element !== inputOutput;
-      });
-
-      modeling.updateModdleProperties(element, extensionElements, {
-        values: filtered
-      });
-    }
-  }, true);
+        modeling.updateModdleProperties(element, extensionElements, { values });
+      }
+    }, true);
+  }
 }
-
 
 UpdateInputOutputBehavior.$inject = [
   'eventBus',
   'modeling'
 ];
-
-inherits(UpdateInputOutputBehavior, CommandInterceptor);
-
-
-// helper //////////////////
-
-function getInputParameters(inputOutput) {
-  return inputOutput.get('inputParameters');
-}
-
-function getOutputParameters(inputOutput) {
-  return inputOutput.get('outputParameters');
-}
-
-function getInputOutput(businessObject) {
-  const extensionElements = businessObject.get('extensionElements');
-
-  if (!extensionElements) {
-    return;
-  }
-
-  const values = extensionElements.get('values');
-
-  return values.find((value) => {
-    return is(value, 'camunda:InputOutput');
-  });
-}
-
-function isEmpty(inputOutput) {
-  const inputParameters = getInputParameters(inputOutput);
-  const outputParameters = getOutputParameters(inputOutput);
-
-  return inputParameters.length === 0 && outputParameters.length === 0;
-}

--- a/lib/camunda-platform/features/modeling/behavior/UpdateResultVariableBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateResultVariableBehavior.js
@@ -1,12 +1,6 @@
-import inherits from 'inherits';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
 
-import {
-  is
-} from 'bpmn-js/lib/util/ModelUtil';
-
-import {
-  has
-} from 'min-dash';
+import { has } from 'min-dash';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
@@ -14,41 +8,42 @@ const HIGH_PRIORITY = 5000;
 
 
 /**
- * Camunda BPMN specific `camunda:resultVariable` behavior.
- *
- * When `camunda:resultVariable` is removed from a service task like element
- * `camunda:mapDecisionResult` for the element will be cleaned up.
+ * Camunda BPMN specific camunda:resultVariable behavior.
  */
-export default function UpdateResultVariableBehavior(eventBus) {
+export default class UpdateResultVariableBehavior extends CommandInterceptor {
+  constructor(eventBus) {
+    super(eventBus);
 
-  CommandInterceptor.call(this, eventBus);
-
-  this.preExecute([ 'properties-panel.update-businessobject', 'element.updateProperties' ],
-    HIGH_PRIORITY, function(context) {
+    /**
+     * Remove camunda:mapDecisionResult on camunda:resultVariable removed.
+     */
+    this.preExecute([
+      'element.updateProperties',
+      'properties-panel.update-businessobject'
+    ], HIGH_PRIORITY, function(context) {
       const {
         element,
         properties
       } = context;
 
       if (
-        is(element, 'camunda:DmnCapable') &&
-        has(properties, 'camunda:resultVariable') &&
-        isEmpty(properties['camunda:resultVariable'])
+        is(element, 'camunda:DmnCapable')
+        && has(properties, 'camunda:resultVariable')
+        && isEmpty(properties[ 'camunda:resultVariable' ])
       ) {
-        properties['camunda:mapDecisionResult'] = null;
+        properties[ 'camunda:mapDecisionResult' ] = null;
       }
     }, true);
-}
 
+  }
+}
 
 UpdateResultVariableBehavior.$inject = [
   'eventBus'
 ];
 
-inherits(UpdateResultVariableBehavior, CommandInterceptor);
 
-
-// helper //////////////////
+// helpers //////////
 
 function isEmpty(value) {
   return value == undefined || value === '';

--- a/lib/camunda-platform/features/modeling/behavior/UserTaskFormsBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UserTaskFormsBehavior.js
@@ -1,18 +1,24 @@
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-import { isUndefined } from 'min-dash';
+import {
+  has,
+  isUndefined
+} from 'min-dash';
 
 
 /**
- * Camunda BPMN specific user task forms behavior ensuring that only one of the following options is configured:
- *
- * 1. embedded, external or Camunda forms using camunda:formKey
- * 2. Camunda forms using camunda:formRef
+ * Camunda BPMN specific user task forms behavior.
  */
 export default class UserTaskFormsBehavior extends CommandInterceptor {
   constructor(eventBus) {
     super(eventBus);
 
+    /**
+     * Ensure that only one of the following options is configured:
+     *
+     * 1. embedded, external or Camunda forms using camunda:formKey
+     * 2. Camunda forms using camunda:formRef
+     */
     this.preExecute([
       'element.updateProperties',
       'element.updateModdleProperties',
@@ -26,13 +32,13 @@ export default class UserTaskFormsBehavior extends CommandInterceptor {
         context.element.businessObject
       );
 
-      if ('camunda:formKey' in properties) {
+      if (has(properties, 'camunda:formKey')) {
         Object.assign(properties, {
           'camunda:formRef': undefined,
           'camunda:formRefBinding': undefined,
           'camunda:formRefVersion': undefined
         });
-      } else if ('camunda:formRef' in properties) {
+      } else if (has(properties, 'camunda:formRef')) {
         Object.assign(properties, {
           'camunda:formKey': undefined
         });
@@ -44,21 +50,21 @@ export default class UserTaskFormsBehavior extends CommandInterceptor {
           });
         }
 
-        if (!('camunda:formRefBinding' in properties) && isUndefined(businessObject.get('camunda:formRefBinding'))) {
+        if (!has(properties, 'camunda:formRefBinding') && isUndefined(businessObject.get('camunda:formRefBinding'))) {
           Object.assign(properties, {
             'camunda:formRefBinding': 'latest'
           });
         }
       }
 
-      if ('camunda:formRefBinding' in properties && properties[ 'camunda:formRefBinding' ] !== 'version') {
+      if (has(properties, 'camunda:formRefBinding') && properties[ 'camunda:formRefBinding' ] !== 'version') {
         Object.assign(properties, {
           'camunda:formRefVersion': undefined
         });
       }
     }, true);
+
   }
 }
-
 
 UserTaskFormsBehavior.$inject = [ 'eventBus' ];

--- a/lib/camunda-platform/helper/InputOutputHelper.js
+++ b/lib/camunda-platform/helper/InputOutputHelper.js
@@ -1,0 +1,29 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+
+export function getInputOutput(businessObject) {
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return;
+  }
+
+  return extensionElements.get('values').find((value) => {
+    return is(value, 'camunda:InputOutput');
+  });
+}
+
+export function getInputParameters(inputOutput) {
+  return inputOutput.get('inputParameters');
+}
+
+export function getOutputParameters(inputOutput) {
+  return inputOutput.get('outputParameters');
+}
+
+export function isInputOutputEmpty(inputOutput) {
+  const inputParameters = getInputParameters(inputOutput);
+  const outputParameters = getOutputParameters(inputOutput);
+
+  return !inputParameters.length && !outputParameters.length;
+}

--- a/test/camunda-cloud/features/modeling/CreateZeebeBoundaryEventBehaviorSpec.js
+++ b/test/camunda-cloud/features/modeling/CreateZeebeBoundaryEventBehaviorSpec.js
@@ -3,29 +3,35 @@ import {
   inject
 } from 'test/TestHelper';
 
-import modelingModule from 'bpmn-js/lib/features/modeling';
-import coreModule from 'bpmn-js/lib/core';
 import contextPadModule from 'bpmn-js/lib/features/context-pad';
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
 import paletteModule from 'bpmn-js/lib/features/palette';
 
 import zeebeModelingModule from 'lib/camunda-cloud/features/modeling';
 
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
 import processDiagramXML from './process-empty.bpmn';
 
 
-describe('camunda-cloud/features/modeling - create boundary events behavior', function() {
+describe('camunda-cloud/features/modeling - CreateBoundaryEventsBehavior', function() {
 
   const testModules = [
-    coreModule,
     contextPadModule,
-    paletteModule,
+    coreModule,
     modelingModule,
+    paletteModule,
     zeebeModelingModule
   ];
 
   beforeEach(bootstrapCamundaCloudModeler(processDiagramXML, { modules: testModules }));
 
-  it('should execute on attach', inject(function(canvas, elementFactory, modeling, bpmnFactory) {
+
+  it('should execute on attach', inject(function(bpmnFactory, canvas, elementFactory, modeling) {
 
     // given
     const messageEventDefinition = bpmnFactory.create('bpmn:MessageEventDefinition');
@@ -35,7 +41,7 @@ describe('camunda-cloud/features/modeling - create boundary events behavior', fu
     });
 
     const intermediateEvent = elementFactory.create('shape', {
-      id: messageIntermediateCatchEvent.id,
+      id: messageIntermediateCatchEvent.get('id'),
       businessObject: messageIntermediateCatchEvent
     });
 
@@ -45,40 +51,46 @@ describe('camunda-cloud/features/modeling - create boundary events behavior', fu
     modeling.createShape(task, { x: 100, y: 100 }, rootElement);
 
     // when
-    const newEvent = modeling.createShape(intermediateEvent, { x: 50 + 15, y: 100 }, task, { attach: true });
+    const newEvent = modeling.createShape(intermediateEvent, { x: 100, y: 100 }, task, { attach: true });
 
     // then
-    expect(newEvent.type).to.equal('bpmn:BoundaryEvent');
-    expect(newEvent.businessObject.attachedToRef).to.equal(task.businessObject);
-    expect(newEvent.businessObject.eventDefinitions[0]).to.not.be.null;
+    expect(newEvent).to.exist;
+    expect(is(newEvent, 'bpmn:BoundaryEvent')).to.be.true;
+
+    const businessObject = getBusinessObject(newEvent);
+
+    expect(businessObject.get('attachedToRef')).to.equal(getBusinessObject(task));
+    expect(businessObject.get('eventDefinitions')[ 0 ]).to.exist;
   }));
 
 
-  it('should execute on attach (without event definition)', inject(
-    function(canvas, elementFactory, modeling, bpmnFactory) {
+  it('should execute on attach (without event definition)', inject(function(bpmnFactory, canvas, elementFactory, modeling) {
 
-      // given
-      const messageIntermediateCatchEvent = bpmnFactory.create('bpmn:IntermediateCatchEvent');
+    // given
+    const messageIntermediateCatchEvent = bpmnFactory.create('bpmn:IntermediateCatchEvent');
 
-      const intermediateEvent = elementFactory.create('shape', {
-        id: messageIntermediateCatchEvent.id,
-        businessObject: messageIntermediateCatchEvent
-      });
+    const intermediateEvent = elementFactory.create('shape', {
+      id: messageIntermediateCatchEvent.get('id'),
+      businessObject: messageIntermediateCatchEvent
+    });
 
-      const rootElement = canvas.getRootElement(),
-            task = elementFactory.createShape({ type: 'bpmn:Task' });
+    const rootElement = canvas.getRootElement(),
+          task = elementFactory.createShape({ type: 'bpmn:Task' });
 
-      modeling.createShape(task, { x: 100, y: 100 }, rootElement);
+    modeling.createShape(task, { x: 100, y: 100 }, rootElement);
 
-      // when
-      const newEvent = modeling.createShape(intermediateEvent, { x: 50 + 15, y: 100 }, task, { attach: true });
+    // when
+    const newEvent = modeling.createShape(intermediateEvent, { x: 100, y: 100 }, task, { attach: true });
 
-      // then
-      expect(newEvent.type).to.equal('bpmn:BoundaryEvent');
-      expect(newEvent.businessObject.attachedToRef).to.equal(task.businessObject);
-      expect(newEvent.businessObject.eventDefinitions).to.be.undefined;
-    }
-  ));
+    // then
+    expect(newEvent).to.exist;
+    expect(is(newEvent, 'bpmn:BoundaryEvent')).to.be.true;
+
+    const businessObject = getBusinessObject(newEvent);
+
+    expect(businessObject.get('attachedToRef')).to.equal(getBusinessObject(task));
+    expect(businessObject.get('eventDefinitions')).to.be.empty;
+  }));
 
 
   it('should NOT execute on drop', inject(function(canvas, elementFactory, modeling) {
@@ -95,7 +107,7 @@ describe('camunda-cloud/features/modeling - create boundary events behavior', fu
 
     // then
     expect(newEvent).to.exist;
-    expect(newEvent.type).to.equal('bpmn:IntermediateCatchEvent');
+    expect(is(newEvent, 'bpmn:IntermediateCatchEvent')).to.be.true;
   }));
 
 });

--- a/test/camunda-cloud/features/modeling/CreateZeebeCallActivityBehaviorSpec.js
+++ b/test/camunda-cloud/features/modeling/CreateZeebeCallActivityBehaviorSpec.js
@@ -11,9 +11,9 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import modelingModule from 'bpmn-js/lib/features/modeling';
 import copyPasteModule from 'diagram-js/lib/features/copy-paste';
 import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
 
 import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 
@@ -29,7 +29,7 @@ import emptyProcessDiagramXML from './process-empty.bpmn';
 import callActivitiesXML from './process-call-activities.bpmn';
 
 
-describe('camunda-cloud/features/modeling - create call activities behavior', function() {
+describe('camunda-cloud/features/modeling - CreateCallActivitiesBehavior', function() {
 
   const moddleExtensions = {
     zeebe: zeebeModdleExtensions
@@ -51,8 +51,7 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
       }));
 
 
-      it('should execute when creating bpmn:CallActivity', inject(function(canvas,
-          modeling) {
+      it('should execute when creating bpmn:CallActivity', inject(function(canvas, modeling) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -64,12 +63,11 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
         const calledElementExtension = getCalledElement(newShape);
 
         expect(calledElementExtension).to.exist;
-        expect(calledElementExtension.propagateAllChildVariables).to.be.false;
+        expect(calledElementExtension.get('zeebe:propagateAllChildVariables')).to.be.false;
       }));
 
 
-      it('should not execute when creating bpmn:Task', inject(function(canvas,
-          modeling) {
+      it('should not execute when creating bpmn:Task', inject(function(canvas, modeling) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -80,7 +78,7 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
         // then
         const calledElementExtension = getCalledElement(newShape);
 
-        expect(calledElementExtension).to.be.undefined;
+        expect(calledElementExtension).not.to.exist;
       }));
 
     });
@@ -89,10 +87,10 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
     describe('when copying bpmn:CallActivity', function() {
 
       const testModules = [
+        copyPasteModule,
         coreModule,
         modelingModule,
-        zeebeModelingModule,
-        copyPasteModule
+        zeebeModelingModule
       ];
 
       beforeEach(bootstrapCamundaCloudModeler(callActivitiesXML, {
@@ -101,15 +99,16 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
       }));
 
 
-      it('should re-use existing extensionElements', inject(function(canvas,
-          elementRegistry, copyPaste) {
+      it('should re-use existing extensionElements', inject(function(canvas, copyPaste, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
+
         const callActivity = elementRegistry.get('CallActivity_1');
 
         // when
         copyPaste.copy(callActivity);
+
         const elements = copyPaste.paste({
           element: rootElement,
           point: {
@@ -119,25 +118,24 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
         });
 
         // then
-        const pastedCallActivity = find(elements, function(element) {
-          return is(element, 'bpmn:CallActivity');
-        });
+        const pastedCallActivity = find(elements, (element) => is(element, 'bpmn:CallActivity'));
 
         const calledElementExtensions = getCalledElements(pastedCallActivity);
 
-        expect(calledElementExtensions.length).to.equal(1);
+        expect(calledElementExtensions).to.have.length(1);
       }));
 
 
-      it('should not alter existing propagateAllChildVariables attribute', inject(function(canvas,
-          elementRegistry, copyPaste) {
+      it('should not alter existing propagateAllChildVariables attribute', inject(function(canvas, copyPaste, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
+
         const callActivity = elementRegistry.get('CallActivity_1');
 
         // when
         copyPaste.copy(callActivity);
+
         const elements = copyPaste.paste({
           element: rootElement,
           point: {
@@ -146,32 +144,30 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
           }
         });
 
-        // assume
-        const pastedCallActivity = find(elements, function(element) {
-          return is(element, 'bpmn:CallActivity');
-        });
+        // then
+        const pastedCallActivity = find(elements, (element) => is(element, 'bpmn:CallActivity'));
 
         const calledElementExtensions = getCalledElements(pastedCallActivity);
 
-        expect(calledElementExtensions.length).to.equal(1);
+        expect(calledElementExtensions).to.have.length(1);
 
-        // then
         const calledElementExtension = getCalledElement(pastedCallActivity);
 
         expect(calledElementExtension).to.exist;
-        expect(calledElementExtension.propagateAllChildVariables).to.be.true;
+        expect(calledElementExtension.get('zeebe:propagateAllChildVariables')).to.be.true;
       }));
 
 
-      it('should not alter existing processRef attribute', inject(function(canvas,
-          elementRegistry, copyPaste) {
+      it('should not alter existing processRef attribute', inject(function(canvas, copyPaste, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
+
         const callActivity = elementRegistry.get('CallActivity_1');
 
         // when
         copyPaste.copy(callActivity);
+
         const elements = copyPaste.paste({
           element: rootElement,
           point: {
@@ -180,56 +176,53 @@ describe('camunda-cloud/features/modeling - create call activities behavior', fu
           }
         });
 
-        // assume
-        const pastedCallActivity = find(elements, function(element) {
-          return is(element, 'bpmn:CallActivity');
-        });
+        // then
+        const pastedCallActivity = find(elements, (element) => is(element, 'bpmn:CallActivity'));
 
         const calledElementExtensions = getCalledElements(pastedCallActivity);
 
-        expect(calledElementExtensions.length).to.equal(1);
+        expect(calledElementExtensions).to.have.length(1);
 
-        // then
         const calledElementExtension = getCalledElement(pastedCallActivity);
 
         expect(calledElementExtension).to.exist;
-        expect(calledElementExtension.processId).to.equal('ProcessRef_1');
+        expect(calledElementExtension.get('zeebe:processId')).to.equal('ProcessRef_1');
       }));
 
 
-      // a legacy CallActivity refers to a CallActivity which was created with
-      // a previous version and therefore does not have the propageteAllChildVariables
-      // attribute set yet
-      it('should not alter existing processRef attribute of legacy CallActivity', inject(function(canvas,
-          elementRegistry, copyPaste) {
+      // call activities created with older versions might not have zeebe:propagateAllChildVariables set
+      it('should not alter existing processRef attribute of legacy CallActivity', inject(
+        function(canvas, copyPaste, elementRegistry) {
 
-        // given
-        const rootElement = canvas.getRootElement();
-        const callActivity = elementRegistry.get('CallActivity_2');
+          // given
+          const rootElement = canvas.getRootElement();
 
-        // when
-        copyPaste.copy(callActivity);
-        const elements = copyPaste.paste({
-          element: rootElement,
-          point: {
-            x: 1000,
-            y: 1000
-          }
-        });
+          const callActivity = elementRegistry.get('CallActivity_2');
 
-        // assume
-        const pastedCallActivity = find(elements, function(element) {
-          return is(element, 'bpmn:CallActivity');
-        });
+          // when
+          copyPaste.copy(callActivity);
 
-        const calledElementExtensions = getCalledElements(pastedCallActivity);
-        expect(calledElementExtensions.length).to.equal(1);
+          const elements = copyPaste.paste({
+            element: rootElement,
+            point: {
+              x: 1000,
+              y: 1000
+            }
+          });
 
-        // then
-        const calledElementExtension = getCalledElement(pastedCallActivity);
-        expect(calledElementExtension).to.exist;
-        expect(calledElementExtension.processId).to.equal('ProcessRef_2');
-      }));
+          // then
+          const pastedCallActivity = find(elements, (element) => is(element, 'bpmn:CallActivity'));
+
+          const calledElementExtensions = getCalledElements(pastedCallActivity);
+
+          expect(calledElementExtensions).to.have.length(1);
+
+          const calledElementExtension = getCalledElement(pastedCallActivity);
+
+          expect(calledElementExtension).to.exist;
+          expect(calledElementExtension.get('zeebe:processId')).to.equal('ProcessRef_2');
+        }
+      ));
 
     });
 

--- a/test/camunda-cloud/features/modeling/FormDefinitionBehaviorSpec.js
+++ b/test/camunda-cloud/features/modeling/FormDefinitionBehaviorSpec.js
@@ -3,24 +3,16 @@ import {
   inject
 } from 'test/TestHelper';
 
-import {
-  find
-} from 'min-dash';
+import { getExtensionElements } from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
 
-import {
-  getExtensionElements
-} from 'bpmn-js-properties-panel/lib/helper/ExtensionElementsHelper';
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
-import {
-  getBusinessObject
-} from 'bpmn-js/lib/util/ModelUtil';
-
-import modelingModule from 'bpmn-js/lib/features/modeling';
 import coreModule from 'bpmn-js/lib/core';
-
-import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+import modelingModule from 'bpmn-js/lib/features/modeling';
 
 import zeebeModelingModule from 'lib/camunda-cloud/features/modeling';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 
 import {
   getFormDefinition,
@@ -30,7 +22,7 @@ import {
 import diagramXML from './process-user-tasks.bpmn';
 
 
-describe('camunda-cloud/features/modeling - form definition behavior', function() {
+describe('camunda-cloud/features/modeling - FormDefinitionBehavior', function() {
 
   const moddleExtensions = {
     zeebe: zeebeModdleExtensions
@@ -46,6 +38,7 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
     modules: testModules,
     moddleExtensions
   }));
+
 
   describe('cleanup user task forms', function() {
 
@@ -64,11 +57,11 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
         // then
         const userTaskForms = getUserTaskForms(rootElement);
 
-        expect(userTaskFormExists('userTaskForm_1', userTaskForms)).to.be.false;
+        expect(userTaskFormExists('UserTaskForm_1', userTaskForms)).to.be.false;
       }));
 
 
-      it('should undo', inject(function(canvas, elementRegistry, modeling, commandStack) {
+      it('should undo', inject(function(canvas, commandStack, elementRegistry, modeling) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -83,11 +76,11 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
         // then
         const userTaskForms = getUserTaskForms(rootElement);
 
-        expect(userTaskFormExists('userTaskForm_1', userTaskForms)).to.be.true;
+        expect(userTaskFormExists('UserTaskForm_1', userTaskForms)).to.be.true;
       }));
 
 
-      it('should redo', inject(function(canvas, elementRegistry, modeling, commandStack) {
+      it('should redo', inject(function(canvas, commandStack, elementRegistry, modeling) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -103,7 +96,7 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
         // then
         const userTaskForms = getUserTaskForms(rootElement);
 
-        expect(userTaskFormExists('userTaskForm_1', userTaskForms)).to.be.false;
+        expect(userTaskFormExists('UserTaskForm_1', userTaskForms)).to.be.false;
       }));
 
     });
@@ -111,7 +104,7 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
 
     describe('on replace user task', function() {
 
-      it('should execute', inject(function(canvas, elementRegistry, bpmnReplace) {
+      it('should execute', inject(function(bpmnReplace, canvas, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -126,11 +119,11 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
         // then
         const userTaskForms = getUserTaskForms(rootElement);
 
-        expect(userTaskFormExists('userTaskForm_1', userTaskForms)).to.be.false;
+        expect(userTaskFormExists('UserTaskForm_1', userTaskForms)).to.be.false;
       }));
 
 
-      it('should undo', inject(function(canvas, elementRegistry, bpmnReplace, commandStack) {
+      it('should undo', inject(function(bpmnReplace, canvas, commandStack, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -147,11 +140,11 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
         // then
         const userTaskForms = getUserTaskForms(rootElement);
 
-        expect(userTaskFormExists('userTaskForm_1', userTaskForms)).to.be.true;
+        expect(userTaskFormExists('UserTaskForm_1', userTaskForms)).to.be.true;
       }));
 
 
-      it('should redo', inject(function(canvas, elementRegistry, bpmnReplace, commandStack) {
+      it('should redo', inject(function(bpmnReplace, canvas, commandStack, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -169,7 +162,7 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
         // then
         const userTaskForms = getUserTaskForms(rootElement);
 
-        expect(userTaskFormExists('userTaskForm_1', userTaskForms)).to.be.false;
+        expect(userTaskFormExists('UserTaskForm_1', userTaskForms)).to.be.false;
       }));
 
     });
@@ -181,7 +174,7 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
 
     describe('on copy user task', function() {
 
-      it('should execute', inject(function(canvas, elementRegistry, copyPaste) {
+      it('should execute', inject(function(canvas, copyPaste, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -210,13 +203,13 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
         const userTaskForm = getUserTaskForm(newElement);
 
         // then
-        expect(formDefinition).to.not.eql(oldFormDefinition);
+        expect(formDefinition).not.to.eql(oldFormDefinition);
 
-        expect(userTaskForm).to.not.eql(oldUserTaskForm);
+        expect(userTaskForm).not.to.eql(oldUserTaskForm);
       }));
 
 
-      it('should undo', inject(function(canvas, elementRegistry, copyPaste, commandStack) {
+      it('should undo', inject(function(canvas, commandStack, copyPaste, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -243,7 +236,7 @@ describe('camunda-cloud/features/modeling - form definition behavior', function(
       }));
 
 
-      it('should redo', inject(function(canvas, elementRegistry, copyPaste, commandStack) {
+      it('should redo', inject(function(canvas, commandStack, copyPaste, elementRegistry) {
 
         // given
         const rootElement = canvas.getRootElement();
@@ -286,7 +279,7 @@ function getUserTaskForms(rootElement) {
 }
 
 function userTaskFormExists(id, userTaskForms) {
-  return !!find(userTaskForms, function(form) {
-    return form.get('id') === id;
+  return !!userTaskForms.find((userTaskForm) => {
+    return userTaskForm.get('zeebe:id') === id;
   });
 }

--- a/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorIntegrationSpec.js
+++ b/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorIntegrationSpec.js
@@ -6,7 +6,7 @@ import {
 
 import {
   getOutputParameters,
-  getInputOutput
+  getIoMapping
 } from 'lib/camunda-cloud/helper/InputOutputHelper';
 
 import {
@@ -19,24 +19,21 @@ import {
   query as domQuery
 } from 'min-dom';
 
-import coreModule from 'bpmn-js/lib/core';
-
-import modelingModule from 'bpmn-js/lib/features/modeling';
-
-import propertiesPanelModule from 'bpmn-js-properties-panel';
-
-import propertiesProviderModule from 'lib/camunda-cloud/features/properties-provider';
-
 import selectionModule from 'diagram-js/lib/features/selection';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import propertiesPanelModule from 'bpmn-js-properties-panel';
 
 import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
 
+import propertiesProviderModule from 'lib/camunda-cloud/features/properties-provider';
 import zeebeModelingModules from 'lib/camunda-cloud/features/modeling';
 
 import diagramXML from './process-call-activities.bpmn';
 
 
-describe('camunda-cloud/features/modeling - propagateAllChildVariables (integration tests)', function() {
+describe('camunda-cloud/features/modeling - UpdatePropagateAllChildVariablesBehavior (integration tests)', function() {
 
   const testModules = [
     coreModule,
@@ -84,6 +81,7 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
 
           // when
           selection.select(shape);
+
           clickPropagateAllChildVariablesToggle(container);
         }));
 
@@ -190,6 +188,7 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
 
           // when
           selection.select(shape);
+
           clickPropagateAllChildVariablesToggle(container);
         }));
 
@@ -197,8 +196,8 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
         it('should execute', inject(function() {
 
           // then
-          const inputOutput = getInputOutput(shape);
-          expect(inputOutput).to.not.exist;
+          const inputOutput = getIoMapping(shape);
+          expect(inputOutput).not.to.exist;
         }));
 
 
@@ -212,7 +211,7 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
           expect(outputParameters).to.exist;
           expect(outputParameters.length).to.equal(1);
 
-          const inputOutput = getInputOutput(shape);
+          const inputOutput = getIoMapping(shape);
           expect(inputOutput).to.exist;
         }));
 
@@ -224,8 +223,8 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
           commandStack.redo();
 
           // then
-          const inputOutput = getInputOutput(shape);
-          expect(inputOutput).to.not.exist;
+          const inputOutput = getIoMapping(shape);
+          expect(inputOutput).not.to.exist;
         }));
 
       });
@@ -247,8 +246,8 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
         it('should execute', inject(function() {
 
           // then
-          const inputOutput = getInputOutput(shape);
-          expect(inputOutput).to.not.exist;
+          const inputOutput = getIoMapping(shape);
+          expect(inputOutput).not.to.exist;
         }));
 
 
@@ -262,7 +261,7 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
           expect(outputParameters).to.exist;
           expect(outputParameters.length).to.equal(1);
 
-          const inputOutput = getInputOutput(shape);
+          const inputOutput = getIoMapping(shape);
           expect(inputOutput).to.exist;
         }));
 
@@ -274,8 +273,8 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
           commandStack.redo();
 
           // then
-          const inputOutput = getInputOutput(shape);
-          expect(inputOutput).to.not.exist;
+          const inputOutput = getIoMapping(shape);
+          expect(inputOutput).not.to.exist;
         }));
 
       });
@@ -300,11 +299,13 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
         calledElement = getCalledElement(shape);
 
         // assume
-        const inputOutput = getInputOutput(shape);
-        expect(inputOutput).to.not.exist;
+        const inputOutput = getIoMapping(shape);
+
+        expect(inputOutput).not.to.exist;
 
         // when
         selection.select(shape);
+
         clickAddOutputParameterButton(container);
       }));
 
@@ -312,7 +313,7 @@ describe('camunda-cloud/features/modeling - propagateAllChildVariables (integrat
       it('should execute', inject(function() {
 
         // then
-        expect(calledElement.propagateAllChildVariables).to.equal(false);
+        expect(calledElement.get('propagateAllChildVariables')).to.equal(false);
       }));
 
 
@@ -364,6 +365,7 @@ const getAddOutputParameterButton = (container) => {
 
 const clickAddOutputParameterButton = (container) => {
   const addButton = getAddOutputParameterButton(container);
+
   triggerEvent(addButton, 'click');
 };
 

--- a/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorSpec.js
+++ b/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorSpec.js
@@ -5,7 +5,7 @@ import {
 
 import {
   getOutputParameters,
-  getInputOutput
+  getIoMapping
 } from 'lib/camunda-cloud/helper/InputOutputHelper';
 
 import {
@@ -17,13 +17,12 @@ import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 import diagramXML from './process-call-activities.bpmn';
 
 
-
-describe('camunda-cloud/features/modeling - update propagateAllChildVariables attribute on call activities', function() {
+describe('camunda-cloud/features/modeling - UpdatePropagateAllChildVariablesBehavior', function() {
 
   beforeEach(bootstrapCamundaCloudModeler(diagramXML));
 
 
-  describe('remove outputParameters', function() {
+  describe('removing zeebe:OutputParameters when zeebe:propagateAllChildVariables is set to true', function() {
 
     let element;
 
@@ -49,7 +48,9 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
 
       // then
       const outputParameters = getOutputParameters(element);
-      expect(outputParameters.length).to.equal(0);
+
+      expect(outputParameters).to.exist;
+      expect(outputParameters).to.be.empty;
     }));
 
 
@@ -60,8 +61,9 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
 
       // then
       const outputParameters = getOutputParameters(element);
+
       expect(outputParameters).to.exist;
-      expect(outputParameters.length).to.equal(1);
+      expect(outputParameters).to.have.length(1);
     }));
 
 
@@ -73,13 +75,15 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
 
       // then
       const outputParameters = getOutputParameters(element);
-      expect(outputParameters.length).to.equal(0);
+
+      expect(outputParameters).to.exist;
+      expect(outputParameters).to.be.empty;
     }));
 
   });
 
 
-  describe('remove iOMapping', function() {
+  describe('removing zeebe:IoMapping when zeebe:propagateAllChildVariables is set to true', function() {
 
     let element;
 
@@ -104,8 +108,9 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
     it('should execute', inject(function() {
 
       // then
-      const inputOutput = getInputOutput(element);
-      expect(inputOutput).to.not.exist;
+      const ioMapping = getIoMapping(element);
+
+      expect(ioMapping).not.to.exist;
     }));
 
 
@@ -115,12 +120,14 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
       commandStack.undo();
 
       // then
-      const outputParameters = getOutputParameters(element);
-      expect(outputParameters).to.exist;
-      expect(outputParameters.length).to.equal(1);
+      const ioMapping = getIoMapping(element);
 
-      const inputOutput = getInputOutput(element);
-      expect(inputOutput).to.exist;
+      expect(ioMapping).to.exist;
+
+      const outputParameters = getOutputParameters(element);
+
+      expect(outputParameters).to.exist;
+      expect(outputParameters).to.have.length(1);
     }));
 
 
@@ -131,14 +138,15 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
       commandStack.redo();
 
       // then
-      const inputOutput = getInputOutput(element);
-      expect(inputOutput).to.not.exist;
+      const ioMapping = getIoMapping(element);
+
+      expect(ioMapping).not.to.exist;
     }));
 
   });
 
 
-  describe('set propagateAllChildVariables to false', function() {
+  describe('setting zeebe:propagateAllChildVariables to false on zeebe:Output added', function() {
 
     let element, calledElement;
 
@@ -166,7 +174,7 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
       commandStack.execute('properties-panel.update-businessobject-list', {
         element: element,
         currentObject: ioMapping,
-        propertyName: 'outputParameters',
+        propertyName: 'zeebe:outputParameters',
         objectsToAdd: [ bpmnFactory.create('zeebe:Output') ]
       });
     }));
@@ -175,7 +183,7 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
     it('should execute', inject(function() {
 
       // then
-      expect(calledElement.propagateAllChildVariables).to.equal(false);
+      expect(calledElement.get('propagateAllChildVariables')).to.equal(false);
     }));
 
 
@@ -185,7 +193,7 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
       commandStack.undo();
 
       // assume
-      expect(calledElement.propagateAllChildVariables).to.equal(true);
+      expect(calledElement.get('propagateAllChildVariables')).to.equal(true);
     }));
 
 
@@ -196,7 +204,7 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
       commandStack.redo();
 
       // then
-      expect(calledElement.propagateAllChildVariables).to.equal(false);
+      expect(calledElement.get('propagateAllChildVariables')).to.equal(false);
     }));
 
   });

--- a/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorSpec.js
+++ b/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorSpec.js
@@ -12,87 +12,67 @@ import {
   getCalledElement
 } from 'lib/camunda-cloud/helper/CalledElementHelper';
 
-import coreModule from 'bpmn-js/lib/core';
-
-import modelingModule from 'bpmn-js/lib/features/modeling';
-
-import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
-
-import zeebeModelingModules from 'lib/camunda-cloud/features/modeling';
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import diagramXML from './process-call-activities.bpmn';
 
 
+
 describe('camunda-cloud/features/modeling - update propagateAllChildVariables attribute on call activities', function() {
 
-
-  const testModules = [
-    coreModule,
-    modelingModule,
-    zeebeModelingModules
-  ];
-
-  const moddleExtensions = {
-    zeebe: zeebeModdleExtensions
-  };
-
-  beforeEach(bootstrapCamundaCloudModeler(diagramXML, {
-    modules: testModules,
-    moddleExtensions
-  }));
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
 
 
   describe('remove outputParameters', function() {
 
-    let shape, context;
+    let element;
 
-    beforeEach(inject(function(elementRegistry, eventBus) {
+    beforeEach(inject(function(commandStack, elementRegistry) {
 
       // given
-      shape = elementRegistry.get('CallActivity_3');
+      element = elementRegistry.get('CallActivity_3');
 
-      context = {
-        context: {
-          element: shape,
-          properties: {
-            propagateAllChildVariables: true
-          }
-        }
-      };
+      const businessObject = getBusinessObject(element);
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+      commandStack.execute('properties-panel.update-businessobject', {
+        businessObject,
+        element,
+        properties: {
+          propagateAllChildVariables: true
+        }
+      });
     }));
 
 
     it('should execute', inject(function() {
 
       // then
-      const outputParameters = getOutputParameters(shape);
+      const outputParameters = getOutputParameters(element);
       expect(outputParameters.length).to.equal(0);
     }));
 
 
-    it('should undo', inject(function(eventBus) {
+    it('should undo', inject(function(commandStack) {
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
+      commandStack.undo();
 
       // then
-      const outputParameters = getOutputParameters(shape);
+      const outputParameters = getOutputParameters(element);
       expect(outputParameters).to.exist;
       expect(outputParameters.length).to.equal(1);
     }));
 
 
-    it('should undo/redo', inject(function(eventBus) {
+    it('should undo/redo', inject(function(commandStack) {
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
-      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+      commandStack.undo();
+      commandStack.redo();
 
       // then
-      const outputParameters = getOutputParameters(shape);
+      const outputParameters = getOutputParameters(element);
       expect(outputParameters.length).to.equal(0);
     }));
 
@@ -101,58 +81,57 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
 
   describe('remove iOMapping', function() {
 
-    let shape, context;
+    let element;
 
-    beforeEach(inject(function(eventBus, elementRegistry) {
+    beforeEach(inject(function(commandStack, elementRegistry) {
 
       // given
-      shape = elementRegistry.get('CallActivity_5');
+      element = elementRegistry.get('CallActivity_5');
 
-      context = {
-        context: {
-          element: shape,
-          properties: {
-            propagateAllChildVariables: true
-          }
-        }
-      };
+      const businessObject = getBusinessObject(element);
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+      commandStack.execute('properties-panel.update-businessobject', {
+        businessObject,
+        element,
+        properties: {
+          propagateAllChildVariables: true
+        }
+      });
     }));
 
 
     it('should execute', inject(function() {
 
       // then
-      const inputOutput = getInputOutput(shape);
+      const inputOutput = getInputOutput(element);
       expect(inputOutput).to.not.exist;
     }));
 
 
-    it('should undo', inject(function(eventBus) {
+    it('should undo', inject(function(commandStack) {
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
+      commandStack.undo();
 
       // then
-      const outputParameters = getOutputParameters(shape);
+      const outputParameters = getOutputParameters(element);
       expect(outputParameters).to.exist;
       expect(outputParameters.length).to.equal(1);
 
-      const inputOutput = getInputOutput(shape);
+      const inputOutput = getInputOutput(element);
       expect(inputOutput).to.exist;
     }));
 
 
-    it('should undo/redo', inject(function(eventBus) {
+    it('should undo/redo', inject(function(commandStack) {
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject.reverted', context);
-      eventBus.fire('commandStack.properties-panel.update-businessobject.executed', context);
+      commandStack.undo();
+      commandStack.redo();
 
       // then
-      const inputOutput = getInputOutput(shape);
+      const inputOutput = getInputOutput(element);
       expect(inputOutput).to.not.exist;
     }));
 
@@ -161,27 +140,35 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
 
   describe('set propagateAllChildVariables to false', function() {
 
-    let shape, calledElement, context;
+    let element, calledElement;
 
-    beforeEach(inject(function(eventBus, elementRegistry, elementFactory) {
+    beforeEach(inject(function(bpmnFactory, commandStack, elementRegistry) {
 
       // given
-      shape = elementRegistry.get('CallActivity_7');
-      calledElement = getCalledElement(shape);
+      element = elementRegistry.get('CallActivity_7');
 
-      context = {
-        context: {
-          element: shape,
-          objectsToAdd: [ elementFactory.createShape({ type: 'zeebe:Output' }) ]
-        }
-      };
+      const businessObject = getBusinessObject(element);
 
-      // assume
-      const inputOutput = getInputOutput(shape);
-      expect(inputOutput).to.not.exist;
+      const extensionElements = businessObject.get('extensionElements');
+
+      const ioMapping = bpmnFactory.create('zeebe:IoMapping');
+
+      calledElement = getCalledElement(element);
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject-list.executed', context);
+      commandStack.execute('properties-panel.update-businessobject-list', {
+        element: element,
+        currentObject: extensionElements,
+        propertyName: 'values',
+        objectsToAdd: [ ioMapping ]
+      });
+
+      commandStack.execute('properties-panel.update-businessobject-list', {
+        element: element,
+        currentObject: ioMapping,
+        propertyName: 'outputParameters',
+        objectsToAdd: [ bpmnFactory.create('zeebe:Output') ]
+      });
     }));
 
 
@@ -192,21 +179,21 @@ describe('camunda-cloud/features/modeling - update propagateAllChildVariables at
     }));
 
 
-    it('should undo', inject(function(eventBus) {
+    it('should undo', inject(function(commandStack) {
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject-list.reverted', context);
+      commandStack.undo();
 
       // assume
       expect(calledElement.propagateAllChildVariables).to.equal(true);
     }));
 
 
-    it('should undo/redo', inject(function(eventBus) {
+    it('should undo/redo', inject(function(commandStack) {
 
       // when
-      eventBus.fire('commandStack.properties-panel.update-businessobject-list.reverted', context);
-      eventBus.fire('commandStack.properties-panel.update-businessobject-list.executed', context);
+      commandStack.undo();
+      commandStack.redo();
 
       // then
       expect(calledElement.propagateAllChildVariables).to.equal(false);

--- a/test/camunda-cloud/features/modeling/process-user-tasks.bpmn
+++ b/test/camunda-cloud/features/modeling/process-user-tasks.bpmn
@@ -2,17 +2,17 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1mcvv1o" targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:extensionElements>
-      <zeebe:userTaskForm id="userTaskForm_1">{ components: [ { label: "field", key: "field" } ] }</zeebe:userTaskForm>
-      <zeebe:userTaskForm id="userTaskForm_2">{ components: [ { label: "anotherField", key: "field" } ] }</zeebe:userTaskForm>
+      <zeebe:userTaskForm id="UserTaskForm_1">{ components: [ { label: "field", key: "field" } ] }</zeebe:userTaskForm>
+      <zeebe:userTaskForm id="UserTaskForm_2">{ components: [ { label: "anotherField", key: "field" } ] }</zeebe:userTaskForm>
     </bpmn:extensionElements>
     <bpmn:userTask id="UserTask_1">
       <bpmn:extensionElements>
-        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_1" />
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_1" />
       </bpmn:extensionElements>
     </bpmn:userTask>
     <bpmn:userTask id="UserTask_2">
       <bpmn:extensionElements>
-        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_2" />
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_2" />
       </bpmn:extensionElements>
     </bpmn:userTask>
   </bpmn:process>

--- a/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/camunda-cloud/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -592,8 +592,8 @@ describe('camunda-cloud/features - PopupMenu', function() {
 
       // then
       expect(subProcessEntry).to.exist;
-      expect(sequentialMultiInstanceEntry).to.not.exist;
-      expect(parallelMultiInstanceEntry).to.not.exist;
+      expect(sequentialMultiInstanceEntry).not.to.exist;
+      expect(parallelMultiInstanceEntry).not.to.exist;
     }));
 
 

--- a/test/camunda-cloud/features/properties-provider/parts/FormsSpec.js
+++ b/test/camunda-cloud/features/properties-provider/parts/FormsSpec.js
@@ -84,8 +84,8 @@ describe('camunda-cloud/features/properties-provider - forms definition properti
           selection.select(shape);
 
           // assume
-          expect(getUserTaskForm(shape)).to.not.exist;
-          expect(getFormDefinition(shape)).to.not.exist;
+          expect(getUserTaskForm(shape)).not.to.exist;
+          expect(getFormDefinition(shape)).not.to.exist;
 
           const textBox = getJSONField(container, 'form-json');
 
@@ -108,8 +108,8 @@ describe('camunda-cloud/features/properties-provider - forms definition properti
           commandStack.undo();
 
           // then
-          expect(getUserTaskForm(shape)).to.not.exist;
-          expect(getFormDefinition(shape)).to.not.exist;
+          expect(getUserTaskForm(shape)).not.to.exist;
+          expect(getFormDefinition(shape)).not.to.exist;
 
         }));
 
@@ -277,8 +277,8 @@ describe('camunda-cloud/features/properties-provider - forms definition properti
 
               // then
 
-              expect(getUserTaskForm(shape)).to.not.exist;
-              expect(getFormDefinition(shape)).to.not.exist;
+              expect(getUserTaskForm(shape)).not.to.exist;
+              expect(getFormDefinition(shape)).not.to.exist;
             });
 
 
@@ -300,8 +300,8 @@ describe('camunda-cloud/features/properties-provider - forms definition properti
               commandStack.redo();
 
               // then
-              expect(getUserTaskForm(shape)).to.not.exist;
-              expect(getFormDefinition(shape)).to.not.exist;
+              expect(getUserTaskForm(shape)).not.to.exist;
+              expect(getFormDefinition(shape)).not.to.exist;
             }));
 
           });

--- a/test/camunda-cloud/features/properties-provider/parts/OutputParameterToggleSpec.js
+++ b/test/camunda-cloud/features/properties-provider/parts/OutputParameterToggleSpec.js
@@ -108,7 +108,7 @@ describe('camunda-cloud/features/properties-provider - input output property tab
         // then
         const propagateAllChildVariablesToggle = getPropagateAllChildVariablesToggle(container);
 
-        expect(propagateAllChildVariablesToggle).to.not.exist;
+        expect(propagateAllChildVariablesToggle).not.to.exist;
       }));
 
   });

--- a/test/camunda-platform/features/modeling/DeleteErrorEventDefinitionBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/DeleteErrorEventDefinitionBehaviorSpec.js
@@ -3,20 +3,19 @@ import {
   inject
 } from 'test/TestHelper';
 
-import coreModule from 'bpmn-js/lib/core';
-
-import modelingModule from 'bpmn-js/lib/features/modeling';
-
 import {
   is,
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
 import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
 
 import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
-
-import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import diagramXML from './camunda-error-event-definition-diagram.bpmn';
 
@@ -39,21 +38,23 @@ describe('camunda-platform/features/modeling - DeleteErrorEventDefinitionBehavio
     moddleExtensions
   }));
 
+
   describe('properties-panel.update-businessobject', function() {
 
     describe('camunda:type to non-external', function() {
 
-      let shape, context, businessObject;
+      let shape, businessObject;
 
       beforeEach(inject(function(elementRegistry, commandStack) {
 
         // given
         shape = elementRegistry.get('ServiceTask_1');
+
         businessObject = getBusinessObject(shape);
 
-        context = {
+        const context = {
           element: shape,
-          businessObject: businessObject,
+          businessObject,
           properties: {
             'camunda:type': 'foo'
           }
@@ -109,6 +110,7 @@ describe('camunda-platform/features/modeling - DeleteErrorEventDefinitionBehavio
 
         // given
         shape = elementRegistry.get('ServiceTask_1');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -155,17 +157,16 @@ describe('camunda-platform/features/modeling - DeleteErrorEventDefinitionBehavio
 });
 
 
-// helper ///////////
+// helpers //////////
 
 function getErrorEventDefinitions(businessObject) {
-  return getExtensionElementsList(businessObject, 'camunda:ErrorEventDefinition');
-}
+  const extensionElements = businessObject.get('extensionElements');
 
-function getExtensionElementsList(businessObject, type = undefined) {
-  const elements = ((businessObject.get('extensionElements') &&
-                  businessObject.get('extensionElements').get('values')) || []);
+  if (!extensionElements) {
+    return;
+  }
 
-  return (elements.length && type) ?
-    elements.filter((value) => is(value, type)) :
-    elements;
+  return extensionElements.get('values').filter((element) => {
+    return is(element, 'camunda:ErrorEventDefinition');
+  });
 }

--- a/test/camunda-platform/features/modeling/DeleteRetryTimeCycleBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/DeleteRetryTimeCycleBehaviorSpec.js
@@ -3,20 +3,19 @@ import {
   inject
 } from 'test/TestHelper';
 
-import coreModule from 'bpmn-js/lib/core';
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
 
+import coreModule from 'bpmn-js/lib/core';
 import modelingModule from 'bpmn-js/lib/features/modeling';
 
-import {
-  is,
-  getBusinessObject
-} from 'bpmn-js/lib/util/ModelUtil';
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
 
 import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
-
-import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import diagramXML from './camunda-failed-job-retry-time-cycle-diagram.bpmn';
 
@@ -39,19 +38,21 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
     moddleExtensions
   }));
 
+
   describe('properties-panel.update-businessobject', function() {
 
     describe('asyncBefore to false', function() {
 
-      let shape, context, businessObject;
+      let shape, businessObject;
 
       beforeEach(inject(function(elementRegistry, commandStack) {
 
         // given
         shape = elementRegistry.get('ServiceTask_1');
+
         businessObject = getBusinessObject(shape);
 
-        context = {
+        const context = {
           element: shape,
           businessObject: businessObject,
           properties: {
@@ -100,15 +101,16 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
     describe('asyncAfter to false', function() {
 
-      let shape, context, businessObject;
+      let shape, businessObject;
 
       beforeEach(inject(function(elementRegistry, commandStack) {
 
         // given
         shape = elementRegistry.get('ServiceTask_2');
+
         businessObject = getBusinessObject(shape);
 
-        context = {
+        const context = {
           element: shape,
           businessObject: businessObject,
           properties: {
@@ -162,6 +164,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
         // given
         shape = elementRegistry.get('ServiceTask_3');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -211,6 +214,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
         // given
         shape = elementRegistry.get('TimerCatchEvent_1');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -248,6 +252,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
         // given
         shape = elementRegistry.get('ServiceTask_1');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -263,7 +268,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
       it('should execute', inject(function() {
 
         // then
-        expect(getFailedJobRetryTimeCycleBody(businessObject)).to.be.undefined;
+        expect(getFailedJobRetryTimeCycleBody(businessObject)).not.to.exist;
       }));
 
 
@@ -284,7 +289,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
         commandStack.redo();
 
         // then
-        expect(getFailedJobRetryTimeCycleBody(businessObject)).to.be.undefined;
+        expect(getFailedJobRetryTimeCycleBody(businessObject)).not.to.exist;
       }));
 
     });
@@ -298,6 +303,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
         // given
         shape = elementRegistry.get('ServiceTask_2');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -313,7 +319,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
       it('should execute', inject(function() {
 
         // then
-        expect(getFailedJobRetryTimeCycleBody(businessObject)).to.be.undefined;
+        expect(getFailedJobRetryTimeCycleBody(businessObject)).not.to.exist;
       }));
 
 
@@ -334,7 +340,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
         commandStack.redo();
 
         // then
-        expect(getFailedJobRetryTimeCycleBody(businessObject)).to.be.undefined;
+        expect(getFailedJobRetryTimeCycleBody(businessObject)).not.to.exist;
       }));
 
     });
@@ -348,6 +354,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
         // given
         shape = elementRegistry.get('ServiceTask_3');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -364,7 +371,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
       it('should execute', inject(function() {
 
         // then
-        expect(getFailedJobRetryTimeCycleBody(businessObject)).to.be.undefined;
+        expect(getFailedJobRetryTimeCycleBody(businessObject)).not.to.exist;
       }));
 
 
@@ -385,7 +392,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
         commandStack.redo();
 
         // then
-        expect(getFailedJobRetryTimeCycleBody(businessObject)).to.be.undefined;
+        expect(getFailedJobRetryTimeCycleBody(businessObject)).not.to.exist;
       }));
 
     });
@@ -399,6 +406,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
         // given
         shape = elementRegistry.get('ServiceTask_3');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -440,6 +448,7 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 
         // given
         shape = elementRegistry.get('TimerCatchEvent_1');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -465,19 +474,20 @@ describe('camunda-platform/features/modeling - DeleteRetryTimeCycleBehavior', fu
 });
 
 
-// helper ///////////
+// helpers //////////
 
 function getFailedJobRetryTimeCycleBody(businessObject) {
-  const extElements = getExtensionElementsList(businessObject, 'camunda:FailedJobRetryTimeCycle');
+  const extensionElements = businessObject.get('extensionElements');
 
-  return extElements[0] && extElements[0].body;
-}
+  if (!extensionElements) {
+    return;
+  }
 
-function getExtensionElementsList(businessObject, type = undefined) {
-  const elements = ((businessObject.get('extensionElements') &&
-                  businessObject.get('extensionElements').get('values')) || []);
+  const failedJobRetryTimeCycle = extensionElements.get('values').find((value) => {
+    return is(value, 'camunda:FailedJobRetryTimeCycle');
+  });
 
-  return (elements.length && type) ?
-    elements.filter((value) => is(value, type)) :
-    elements;
+  if (failedJobRetryTimeCycle) {
+    return failedJobRetryTimeCycle.get('camunda:body');
+  }
 }

--- a/test/camunda-platform/features/modeling/UpdateCamundaExclusiveBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UpdateCamundaExclusiveBehaviorSpec.js
@@ -3,19 +3,16 @@ import {
   inject
 } from 'test/TestHelper';
 
-import coreModule from 'bpmn-js/lib/core';
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
+import coreModule from 'bpmn-js/lib/core';
 import modelingModule from 'bpmn-js/lib/features/modeling';
 
-import {
-  getBusinessObject
-} from 'bpmn-js/lib/util/ModelUtil';
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
 
 import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
-
-import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import diagramXML from './camunda-exclusive-diagram.bpmn';
 
@@ -42,15 +39,16 @@ describe('camunda-platform/features/modeling - UpdateCamundaExclusiveBehavior', 
 
     describe('asyncBefore to false', function() {
 
-      let shape, context, businessObject;
+      let shape, businessObject;
 
-      beforeEach(inject(function(elementRegistry, commandStack) {
+      beforeEach(inject(function(commandStack, elementRegistry) {
 
         // given
         shape = elementRegistry.get('ServiceTask_1');
+
         businessObject = getBusinessObject(shape);
 
-        context = {
+        const context = {
           element: shape,
           businessObject: businessObject,
           properties: {
@@ -99,15 +97,16 @@ describe('camunda-platform/features/modeling - UpdateCamundaExclusiveBehavior', 
 
     describe('asyncAfter to false', function() {
 
-      let shape, context, businessObject;
+      let shape, businessObject;
 
-      beforeEach(inject(function(elementRegistry, commandStack) {
+      beforeEach(inject(function(commandStack, elementRegistry) {
 
         // given
         shape = elementRegistry.get('ServiceTask_2');
+
         businessObject = getBusinessObject(shape);
 
-        context = {
+        const context = {
           element: shape,
           businessObject: businessObject,
           properties: {
@@ -161,6 +160,7 @@ describe('camunda-platform/features/modeling - UpdateCamundaExclusiveBehavior', 
 
         // given
         shape = elementRegistry.get('ServiceTask_3');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -214,6 +214,7 @@ describe('camunda-platform/features/modeling - UpdateCamundaExclusiveBehavior', 
 
         // given
         shape = elementRegistry.get('ServiceTask_1');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -264,6 +265,7 @@ describe('camunda-platform/features/modeling - UpdateCamundaExclusiveBehavior', 
 
         // given
         shape = elementRegistry.get('ServiceTask_2');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -314,6 +316,7 @@ describe('camunda-platform/features/modeling - UpdateCamundaExclusiveBehavior', 
 
         // given
         shape = elementRegistry.get('ServiceTask_3');
+
         businessObject = getBusinessObject(shape);
 
         // assume
@@ -365,6 +368,7 @@ describe('camunda-platform/features/modeling - UpdateCamundaExclusiveBehavior', 
 
         // given
         shape = elementRegistry.get('ServiceTask_3');
+
         businessObject = getBusinessObject(shape);
 
         // assume

--- a/test/camunda-platform/features/modeling/UpdateInputOutputBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UpdateInputOutputBehaviorSpec.js
@@ -9,14 +9,13 @@ import {
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import coreModule from 'bpmn-js/lib/core';
-
 import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
 
 import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
-
-import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import diagramXML from './camunda-input-output-diagram.bpmn';
 
@@ -38,6 +37,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
     modules: testModules,
     moddleExtensions
   }));
+
 
   describe('element.updateProperties', function() {
 
@@ -80,7 +80,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         const properties = getProperties(businessObject);
 
         // assume
-        expect(getExtensionElementsList(businessObject)).to.have.length(2);
+        expect(getExtensionElements(businessObject)).to.have.length(2);
 
         inputOutput.set('inputParameters', []);
         extensionElements.set('values', [ inputOutput, properties ]);
@@ -91,7 +91,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         });
 
         // then
-        expect(getExtensionElementsList(businessObject)).to.have.length(1);
+        expect(getExtensionElements(businessObject)).to.have.length(1);
       })
     );
 
@@ -125,7 +125,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
       it('should execute', inject(function() {
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
 
@@ -146,7 +146,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         commandStack.redo();
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
     });
@@ -181,7 +181,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
       it('should execute', inject(function() {
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
 
@@ -202,7 +202,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         commandStack.redo();
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
     });
@@ -245,7 +245,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         const inputOutput = getInputOutput(businessObject);
 
         // assume
-        expect(getExtensionElementsList(businessObject)).to.have.length(2);
+        expect(getExtensionElements(businessObject)).to.have.length(2);
 
         // when
         modeling.updateModdleProperties(shape, inputOutput, {
@@ -253,7 +253,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         });
 
         // then
-        expect(getExtensionElementsList(businessObject)).to.have.length(1);
+        expect(getExtensionElements(businessObject)).to.have.length(1);
       })
     );
 
@@ -283,7 +283,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
       it('should execute', inject(function() {
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
 
@@ -304,7 +304,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         commandStack.redo();
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
     });
@@ -335,7 +335,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
       it('should execute', inject(function() {
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
 
@@ -356,7 +356,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         commandStack.redo();
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
     });
@@ -396,7 +396,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
     );
 
 
-    it('should NOT execute on recently added inputOutput',
+    it('should NOT remove newly added camunda:InputOutput',
       inject(function(elementRegistry, commandStack, bpmnFactory) {
 
         // given
@@ -443,13 +443,13 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         };
 
         // assume
-        expect(getExtensionElementsList(businessObject)).to.have.length(2);
+        expect(getExtensionElements(businessObject)).to.have.length(2);
 
         // when
         commandStack.execute('properties-panel.update-businessobject-list', context);
 
         // then
-        expect(getExtensionElementsList(businessObject)).to.have.length(1);
+        expect(getExtensionElements(businessObject)).to.have.length(1);
       })
     );
 
@@ -486,7 +486,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
       it('should execute', inject(function() {
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
 
@@ -507,7 +507,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         commandStack.redo();
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
     });
@@ -545,7 +545,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
       it('should execute', inject(function() {
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
 
@@ -566,7 +566,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
         commandStack.redo();
 
         // then
-        expect(getInputOutput(businessObject)).to.not.exist;
+        expect(getInputOutput(businessObject)).not.to.exist;
       }));
 
     });
@@ -576,7 +576,7 @@ describe('camunda-platform/features/modeling - UpdateInputOutputBehavior', funct
 });
 
 
-// helper //////////////////
+// helpers //////////
 
 function getOutputParameters(inputOutput) {
   return inputOutput.get('outputParameters');
@@ -587,18 +587,25 @@ function getInputParameters(inputOutput) {
 }
 
 function getInputOutput(businessObject) {
-  return (getExtensionElementsList(businessObject, 'camunda:InputOutput') || [])[0];
+  return getExtensionElements(businessObject, 'camunda:InputOutput')[ 0 ];
 }
 
 function getProperties(businessObject) {
-  return (getExtensionElementsList(businessObject, 'camunda:Properties') || [])[0];
+  return getExtensionElements(businessObject, 'camunda:Properties')[ 0 ];
 }
 
-function getExtensionElementsList(businessObject, type = undefined) {
-  const elements = ((businessObject.get('extensionElements') &&
-                  businessObject.get('extensionElements').get('values')) || []);
+function getExtensionElements(businessObject, type) {
+  const extensionElements = businessObject.get('extensionElements');
 
-  return (elements.length && type) ?
-    elements.filter((value) => is(value, type)) :
-    elements;
+  if (!extensionElements) {
+    return;
+  }
+
+  if (!type) {
+    return extensionElements.get('values');
+  }
+
+  return extensionElements.get('values').filter((element) => {
+    return is(element, type);
+  });
 }

--- a/test/camunda-platform/features/modeling/UpdateResultVariableBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UpdateResultVariableBehaviorSpec.js
@@ -3,19 +3,18 @@ import {
   inject
 } from 'test/TestHelper';
 
-import coreModule from 'bpmn-js/lib/core';
-
-import modelingModule from 'bpmn-js/lib/features/modeling';
-
 import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
 import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
 
 import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
-
-import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import diagramXML from './camunda-result-variable-diagram.bpmn';
 
@@ -37,6 +36,7 @@ describe('camunda-platform/features/modeling - UpdateResultVariableBehavior', fu
     modules: testModules,
     moddleExtensions
   }));
+
 
   describe('properties-panel.update-businessobject', function() {
 
@@ -66,11 +66,11 @@ describe('camunda-platform/features/modeling - UpdateResultVariableBehavior', fu
       }));
 
 
-      it('should execute', inject(function() {
+      it('should execute', function() {
 
         // then
-        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
-      }));
+        expect(businessObject.get('camunda:mapDecisionResult')).not.to.exist;
+      });
 
 
       it('should undo', inject(function(commandStack) {
@@ -90,7 +90,7 @@ describe('camunda-platform/features/modeling - UpdateResultVariableBehavior', fu
         commandStack.redo();
 
         // then
-        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
+        expect(businessObject.get('camunda:mapDecisionResult')).not.to.exist;
       }));
 
     });
@@ -120,11 +120,11 @@ describe('camunda-platform/features/modeling - UpdateResultVariableBehavior', fu
       }));
 
 
-      it('should execute', inject(function() {
+      it('should execute', function() {
 
         // then
-        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
-      }));
+        expect(businessObject.get('camunda:mapDecisionResult')).not.to.exist;
+      });
 
 
       it('should undo', inject(function(commandStack) {
@@ -144,7 +144,7 @@ describe('camunda-platform/features/modeling - UpdateResultVariableBehavior', fu
         commandStack.redo();
 
         // then
-        expect(businessObject.get('camunda:mapDecisionResult')).to.not.exist;
+        expect(businessObject.get('camunda:mapDecisionResult')).not.to.exist;
       }));
 
     });

--- a/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
@@ -7,19 +7,18 @@ import {
   getBpmnJS
 } from 'bpmn-js/test/helper';
 
-import coreModule from 'bpmn-js/lib/core';
-
-import modelingModule from 'bpmn-js/lib/features/modeling';
-
 import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
+
 import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda';
 
 import camundaPlatformModelingModules from 'lib/camunda-platform/features/modeling';
-
-import propertiesPanelCommandHandler from 'bpmn-js-properties-panel/lib/cmd';
 
 import diagramXML from './camunda-user-task-forms-diagram.bpmn';
 
@@ -101,7 +100,7 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
             it('should execute', inject(function() {
 
               // then
-              expect(businessObject.get('camunda:formRef')).to.not.exist;
+              expect(businessObject.get('camunda:formRef')).not.to.exist;
               expect(businessObject.get('camunda:formRefBinding')).not.to.exist;
               expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
             }));
@@ -126,7 +125,7 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
               commandStack.redo();
 
               // then
-              expect(businessObject.get('camunda:formRef')).to.not.exist;
+              expect(businessObject.get('camunda:formRef')).not.to.exist;
               expect(businessObject.get('camunda:formRefBinding')).not.to.exist;
               expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
             }));
@@ -166,7 +165,7 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
             it('should execute', inject(function() {
 
               // then
-              expect(businessObject.get('camunda:formKey')).to.not.exist;
+              expect(businessObject.get('camunda:formKey')).not.to.exist;
             }));
 
 
@@ -187,7 +186,7 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
               commandStack.redo();
 
               // then
-              expect(businessObject.get('camunda:formKey')).to.not.exist;
+              expect(businessObject.get('camunda:formKey')).not.to.exist;
             }));
 
           });


### PR DESCRIPTION
Preparations for moving the behaviors to a different place. No functionality was changed, only fixed if necessary.

## Changes

### Fixes

* behaviors use commands instead of monkey patching

### Refactorings

* streamline comments
* drop inherits helper
* assign uppercase IDs to new user task forms
* tests use command stack to test undo/redo
* access business object properties using getters
* code style
* refactor helpers

---

Related to https://github.com/bpmn-io/internal-docs/issues/358
Closes https://github.com/camunda/camunda-bpmn-js/issues/53