### PR TITLE
chore: add prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:distro": "node tasks/test-distro.js",
     "start:base": "cross-env SINGLE_START=base-modeler npm run dev",
     "start:platform": "cross-env SINGLE_START=camunda-platform-modeler npm run dev",
-    "start:cloud": "cross-env SINGLE_START=camunda-cloud-modeler npm run dev"
+    "start:cloud": "cross-env SINGLE_START=camunda-cloud-modeler npm run dev",
+    "prepublishOnly": "run-s distro test:distro"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This can be tested with `npm publish --dry-run`.