### PR TITLE
Set `camunda:formRefBinding` to latest if `camunda:formRef` is being set

### DIFF
--- a/lib/camunda-platform/features/modeling/behavior/UserTaskFormsBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UserTaskFormsBehavior.js
@@ -20,6 +20,12 @@ export default class UserTaskFormsBehavior extends CommandInterceptor {
     ], function(context) {
       const { properties } = context;
 
+      const businessObject = (
+        context.moddleElement ||
+        context.businessObject ||
+        context.element.businessObject
+      );
+
       if ('camunda:formKey' in properties) {
         Object.assign(properties, {
           'camunda:formRef': undefined,
@@ -35,6 +41,12 @@ export default class UserTaskFormsBehavior extends CommandInterceptor {
           Object.assign(properties, {
             'camunda:formRefBinding': undefined,
             'camunda:formRefVersion': undefined
+          });
+        }
+
+        if (!('camunda:formRefBinding' in properties) && isUndefined(businessObject.get('camunda:formRefBinding'))) {
+          Object.assign(properties, {
+            'camunda:formRefBinding': 'latest'
           });
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1841,9 +1841,9 @@
       "dev": true
     },
     "camunda-bpmn-moddle": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-6.1.0.tgz",
-      "integrity": "sha512-jePzLVDh2FlZe9C5e4sp9PuJRte9S1PcXzMiMTnuzmxSvd2nMGV0jMb2ieR2ktC079UEZ/E0wEfIJ9q7Cm/3xg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-6.1.1.tgz",
+      "integrity": "sha512-HbYXm9lNPVnGfq4jRRtvR4YgRgw6hGwJ2wFIBghyOQ8fYsqUAPAZ4MJ1pQASZM+XpxmEyRTowc4SiHcAcFbDYw==",
       "requires": {
         "min-dash": "^3.5.2"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bpmn-js-executable-fix": "^0.1.3",
     "bpmn-js-properties-panel": "^0.45.0",
     "bpmn-js-signavio-compat": "^1.2.3",
-    "camunda-bpmn-moddle": "^6.1.0",
+    "camunda-bpmn-moddle": "^6.1.1",
     "diagram-js": "^7.3.0",
     "diagram-js-minimap": "^2.0.4",
     "diagram-js-origin": "^1.3.2",

--- a/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
@@ -102,7 +102,7 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
 
               // then
               expect(businessObject.get('camunda:formRef')).to.not.exist;
-              expect(businessObject.get('camunda:formRefBinding')).to.equal('latest');
+              expect(businessObject.get('camunda:formRefBinding')).not.to.exist;
               expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
             }));
 
@@ -127,7 +127,7 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
 
               // then
               expect(businessObject.get('camunda:formRef')).to.not.exist;
-              expect(businessObject.get('camunda:formRefBinding')).to.equal('latest');
+              expect(businessObject.get('camunda:formRefBinding')).not.to.exist;
               expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
             }));
 
@@ -253,7 +253,7 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
 
               // then
               expect(businessObject.get('camunda:formRef')).not.to.exist;
-              expect(businessObject.get('camunda:formRefBinding')).to.equal('latest');
+              expect(businessObject.get('camunda:formRefBinding')).not.to.exist;
               expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
             }));
 

--- a/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
+++ b/test/camunda-platform/features/modeling/UserTaskFormBehaviorSpec.js
@@ -199,6 +199,23 @@ describe('camunda-platform/features/modeling - UserTaskFormsBehavior', function(
 
           describe(type, function() {
 
+            it('should default to <latest>', inject(function(elementRegistry) {
+
+              // when
+              const element = elementRegistry.get(`${ prefix }_FormKey`);
+
+              const businessObject = getBusinessObject(element);
+
+              // when
+              fn(element, { 'camunda:formRef': 'foo' });
+
+              // then
+              expect(businessObject.get('camunda:formRef')).to.equal('foo');
+              expect(businessObject.get('camunda:formRefBinding')).to.equal('latest');
+              expect(businessObject.get('camunda:formRefVersion')).not.to.exist;
+            }));
+
+
             it('should delete camunda:formRefVersion', inject(function(elementRegistry) {
 
               // when


### PR DESCRIPTION
As a follow up to https://github.com/camunda/camunda-bpmn-moddle/pull/87 this ensures the resulting XML is always a valid, executable diagram.

Related to camunda/camunda-modeler#2484