### PR TITLE
fix(camunda-platform): use relative path in library code

### DIFF
--- a/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
+++ b/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
@@ -3,7 +3,7 @@ import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 import {
   getInputOutput,
   isInputOutputEmpty
-} from 'lib/camunda-platform/helper/InputOutputHelper';
+} from '../../../helper/InputOutputHelper';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 


### PR DESCRIPTION
Let's use relative paths here. Some bundlers will have problems otherwise.

I stumbled over this while linking the current `main` branch to the Camunda Modeler.

```error
ERROR in /Users/niklas.kiefer/bpmn-io/camunda-bpmn-js/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js
Module not found: Error: Can't resolve 'lib/camunda-platform/helper/InputOutputHelper' in '/Users/niklas.kiefer/bpmn-io/camunda-bpmn-js/lib/camunda-platform/features/modeling/behavior'
 @ /Users/niklas.kiefer/bpmn-io/camunda-bpmn-js/lib/camunda-platform/features/modeling/behavior/UpdateInputOutputBehavior.js 2:0-99 22:26-40 29:25-43
 @ /Users/niklas.kiefer/bpmn-io/camunda-bpmn-js/lib/camunda-platform/features/modeling/behavior/index.js
 @ /Users/niklas.kiefer/bpmn-io/camunda-bpmn-js/lib/camunda-platform/features/modeling/index.js
 @ /Users/niklas.kiefer/bpmn-io/camunda-bpmn-js/lib/camunda-platform/Modeler.js
 @ ./src/app/tabs/bpmn/modeler/BpmnModeler.js
 @ ./src/app/tabs/bpmn/modeler/index.js
 @ ./src/app/tabs/bpmn/BpmnEditor.js
 @ ./src/app/tabs/bpmn/BpmnTab.js
 @ ./src/app/tabs/bpmn/index.js
 @ ./src/app/TabsProvider.js
 @ ./src/app/index.js
 @ ./src/index.js
 @ multi ./src/index.js
 ```