### PR TITLE
Rollout cloud templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.13.0-alpha.3
+
+* `FEAT`: add cloud element templates ([#95](https://github.com/camunda/camunda-bpmn-js/pull/95))
+* `DEPS`: update to `bpmn-js@9.0.2`
+* `DEPS`: update to `@bpmn-io/properties-panel@0.11.0`
+* `DEPS`: update to `bpmn-properties-panel@1.0.0-alpha.5`
+* `DEPS`: update to `zeebe-bpmn-moddle@0.11.0`
+
 ## 0.13.0-alpha.2
 
 * `FEAT`: add support for drilldown ([#89](https://github.com/camunda/camunda-bpmn-js/pull/89))

--- a/lib/camunda-cloud/ElementTemplatesValidator.js
+++ b/lib/camunda-cloud/ElementTemplatesValidator.js
@@ -1,0 +1,1 @@
+export { CloudElementTemplatesValidator } from 'bpmn-js-properties-panel';

--- a/lib/camunda-cloud/Modeler.js
+++ b/lib/camunda-cloud/Modeler.js
@@ -18,6 +18,7 @@ import rulesModule from './features/rules';
 
 import {
   ZeebePropertiesProviderModule as zeebePropertiesProviderModule,
+  CloudElementTemplatesPropertiesProviderModule as cloudElementTemplatesPropertiesProvider,
   ZeebeDescriptionProvider
 } from 'bpmn-js-properties-panel';
 
@@ -58,6 +59,7 @@ Modeler.prototype._camundaCloudModules = [
   popupMenuModule,
   rulesModule,
   zeebePropertiesProviderModule,
+  cloudElementTemplatesPropertiesProvider,
   zeebeModdleExtension
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -906,11 +906,12 @@
       "integrity": "sha512-a8Ri5q2uhCrHJ415BR9ZulajvOw0SX2Eh0jxwoMZ/ynxcZPBbOKm6kW6HAQFJp0EFHwftMiJstcvIcSjyz0hZA=="
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.4.0.tgz",
-      "integrity": "sha512-cJtmUHn/4QpkeGQ/tUBQO020Cr1x2AILYczzMioRCGRSEekR/8wSaeEFuEx5ujFNDbHSx2lLN5P2ZmHlpD1Tmg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.5.0.tgz",
+      "integrity": "sha512-v/gfuYs7AOsQUzGmWBEupFGZiylCzqapBoZrjavewnPPbDOzLvbHZ1bnYPre/7b/wdnf4ayx0bf/NCC/AEySVg==",
       "requires": {
-        "@camunda/element-templates-json-schema": "^0.6.0",
+        "@camunda/element-templates-json-schema": "^0.7.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.1.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^3.8.1"
       }
@@ -924,9 +925,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.10.2.tgz",
-      "integrity": "sha512-ljH/xMQapQ4k5NT8YQYt9O9iqRn2Mg77aQh4p5RBDdAq51VxhokClaxe6P1L3pkbB3jQUBM+SO18JhLjv/VzTw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.11.0.tgz",
+      "integrity": "sha512-/1lZiwhCdAsapXKMjzVFc6jdyzU5Ue8wq/mMSFLVvAatxlHHrxTwYAqEW9zA0ZBqIm8JQbl6wptGMG/6ICZPGA==",
       "requires": {
         "classnames": "^2.3.1",
         "min-dash": "^3.7.0",
@@ -934,9 +935,14 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.6.0.tgz",
-      "integrity": "sha512-sfNIOKSfx/VQesCe1+m1izfIZS64NWDZq3teyMzzfJkn37u0ngwIwEXlc7Voj8Qcg2paePT8HmEgp+TJP39V3Q=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
+      "integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ=="
+    },
+    "@camunda/zeebe-element-templates-json-schema": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.1.0.tgz",
+      "integrity": "sha512-E5mie+Q+/0Rk12GerNRWZP6aIWFXo4KfC++6tFJUvKt8la4ZvsPpagB7F8Oiahd56/gUqOicJ7+yPyQ85JnFgA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -2025,11 +2031,11 @@
       "integrity": "sha512-dXvRIUD+NuB/fByFP8r4/Vr8L9Buv/hdRQt0g5wzCHAoF+nW0C/Uv+EjRjwqqFr7AQr1XR+L1ADL3BDyKgeuWw=="
     },
     "bpmn-js-properties-panel": {
-      "version": "1.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.3.tgz",
-      "integrity": "sha512-aDnuxMS1rFmrR6EKhihCm7luf9yokcY9nXa1zELQ0CH8eVbFr4SIyRmSvfBPuJbuB7uYnH9gjG0W5uqjiwtQfw==",
+      "version": "1.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.5.tgz",
+      "integrity": "sha512-AXunjjthnApd25M0A0OIVxwIWoJc/BvNVCObf0Ushh86PqESzjAbDkTdtbUGxnj4ukiFJB390K5b5NezUEL5IQ==",
       "requires": {
-        "@bpmn-io/element-templates-validator": "^0.4.0",
+        "@bpmn-io/element-templates-validator": "^0.5.0",
         "@bpmn-io/extract-process-variables": "^0.4.4",
         "array-move": "^3.0.1",
         "classnames": "^2.3.1",
@@ -6995,9 +7001,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.10.0.tgz",
-      "integrity": "sha512-1wnUWYPVLFxAEM78hiN7kO2NmKK0OHGnT0DcI/MP6KO6HcmdHBgTjsSY4qRNM3G1MeKA/zVJ1OZ0Onz9krbeZg=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.11.0.tgz",
+      "integrity": "sha512-ehNQa2Kt9B1bwWJCF8Fs4SkroaSe+VH5Y4ql4T1hHuOSMJiwuMekFIs3UAJyS0ZyBhcJbUW1C1NPwXcD8u5IRA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,18 +40,18 @@
   "license": "MIT",
   "dependencies": {
     "@bpmn-io/align-to-origin": "^0.7.0",
-    "@bpmn-io/properties-panel": "^0.10.2",
+    "@bpmn-io/properties-panel": "^0.11.0",
     "bpmn-js": "^9.0.2",
     "bpmn-js-disable-collapsed-subprocess": "^0.1.3",
     "bpmn-js-executable-fix": "^0.1.3",
-    "bpmn-js-properties-panel": "~1.0.0-alpha.3",
+    "bpmn-js-properties-panel": "~1.0.0-alpha.5",
     "camunda-bpmn-moddle": "^6.1.1",
     "diagram-js": "^8.1.1",
     "diagram-js-minimap": "^2.1.0",
     "diagram-js-origin": "^1.3.2",
     "inherits": "^2.0.4",
     "min-dash": "^3.8.1",
-    "zeebe-bpmn-moddle": "^0.10.0"
+    "zeebe-bpmn-moddle": "^0.11.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",

--- a/styles/camunda-cloud-modeler.css
+++ b/styles/camunda-cloud-modeler.css
@@ -1,1 +1,2 @@
 @import './base-modeler.css';
+@import './element-templates.css';

--- a/test/camunda-cloud/ElementTemplatesValidatorSpec.js
+++ b/test/camunda-cloud/ElementTemplatesValidatorSpec.js
@@ -1,0 +1,23 @@
+import { CloudElementTemplatesValidator } from 'lib/camunda-cloud/ElementTemplatesValidator';
+
+
+describe('camunda-cloud - ElementTemplatesValidator', function() {
+
+  [
+    'addAll',
+    'add',
+    'getErrors',
+    'getValidTemplates',
+    'isSchemaValid',
+  ].forEach(function(method) {
+    it(`should export ${method}`, function() {
+
+      // given
+      const validator = new CloudElementTemplatesValidator();
+
+      // then
+      expect(validator[method]).to.exist;
+    });
+  });
+
+});

--- a/test/camunda-cloud/ModelerSpec.js
+++ b/test/camunda-cloud/ModelerSpec.js
@@ -15,12 +15,18 @@ import Modeler from 'lib/camunda-cloud/Modeler';
 import simpleXml from 'test/fixtures/simple.bpmn';
 
 import propertiesPanelCSS from 'bpmn-js-properties-panel/dist/assets/properties-panel.css';
+import elementTemplatesCSS from 'bpmn-js-properties-panel/dist/assets/element-templates.css';
 
 var singleStart = window.__env__ && window.__env__.SINGLE_START === 'camunda-cloud-modeler';
 
 insertCSS(
   'properties-panel.css',
   propertiesPanelCSS
+);
+
+insertCSS(
+  'element-templates.css',
+  elementTemplatesCSS
 );
 
 insertCSS('test-panel.css', `
@@ -124,6 +130,22 @@ describe('<CamundaCloudModeler>', function() {
       expect(modeler.get('zeebeModdleExtension')).to.exist;
       expect(modeler.get('propertiesPanel')).to.exist;
       expect(modeler.get('zeebePropertiesProvider')).to.exist;
+    });
+
+  });
+
+
+  it('should inject element templates modules', function() {
+
+    // when
+    return createModeler(simpleXml).then(function(result) {
+
+      var modeler = result.modeler;
+
+      // then
+      expect(modeler.get('elementTemplatesLoader')).to.exist;
+      expect(modeler.get('elementTemplates')).to.exist;
+      expect(modeler.get('elementTemplatesPropertiesProvider')).to.exist;
     });
 
   });


### PR DESCRIPTION
* Bumping properties panel dependencies
* Add `cloud-element-templates` provider available in Camunda Cloud Modeler
* Re-export cloud element templates validator to make it available in Camunda Modeler
* Prepare next alpha release

Related to https://github.com/camunda/camunda-modeler/issues/2731