### PR TITLE
fix: move properties panel deps to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -909,6 +909,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.5.0.tgz",
       "integrity": "sha512-v/gfuYs7AOsQUzGmWBEupFGZiylCzqapBoZrjavewnPPbDOzLvbHZ1bnYPre/7b/wdnf4ayx0bf/NCC/AEySVg==",
+      "dev": true,
       "requires": {
         "@camunda/element-templates-json-schema": "^0.7.0",
         "@camunda/zeebe-element-templates-json-schema": "^0.1.0",
@@ -920,6 +921,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.4.tgz",
       "integrity": "sha512-iStnEVSEtOlZoE3ADMImdwhOhxUjXFdwWsCmmJQlyWH5ISmdRvai0Cxuw0spQEYySgIwFsUB0h+ScOCdW6yEBQ==",
+      "dev": true,
       "requires": {
         "min-dash": "^3.5.2"
       }
@@ -928,6 +930,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.11.0.tgz",
       "integrity": "sha512-/1lZiwhCdAsapXKMjzVFc6jdyzU5Ue8wq/mMSFLVvAatxlHHrxTwYAqEW9zA0ZBqIm8JQbl6wptGMG/6ICZPGA==",
+      "dev": true,
       "requires": {
         "classnames": "^2.3.1",
         "min-dash": "^3.7.0",
@@ -937,12 +940,14 @@
     "@camunda/element-templates-json-schema": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
-      "integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ=="
+      "integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ==",
+      "dev": true
     },
     "@camunda/zeebe-element-templates-json-schema": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.1.0.tgz",
-      "integrity": "sha512-E5mie+Q+/0Rk12GerNRWZP6aIWFXo4KfC++6tFJUvKt8la4ZvsPpagB7F8Oiahd56/gUqOicJ7+yPyQ85JnFgA=="
+      "integrity": "sha512-E5mie+Q+/0Rk12GerNRWZP6aIWFXo4KfC++6tFJUvKt8la4ZvsPpagB7F8Oiahd56/gUqOicJ7+yPyQ85JnFgA==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -1583,7 +1588,8 @@
     "array-move": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
-      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg=="
+      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg==",
+      "dev": true
     },
     "array-union": {
       "version": "2.1.0",
@@ -2034,6 +2040,7 @@
       "version": "1.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.5.tgz",
       "integrity": "sha512-AXunjjthnApd25M0A0OIVxwIWoJc/BvNVCObf0Ushh86PqESzjAbDkTdtbUGxnj4ukiFJB390K5b5NezUEL5IQ==",
+      "dev": true,
       "requires": {
         "@bpmn-io/element-templates-validator": "^0.5.0",
         "@bpmn-io/extract-process-variables": "^0.4.4",
@@ -2298,7 +2305,8 @@
     "classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
+      "dev": true
     },
     "cliui": {
       "version": "7.0.4",
@@ -4059,7 +4067,8 @@
     "json-source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
-      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4411,6 +4420,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5574,7 +5584,8 @@
     "preact-markup": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
-      "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw=="
+      "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -5952,6 +5963,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -6959,7 +6971,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start:base": "cross-env SINGLE_START=base-modeler npm run dev",
     "start:platform": "cross-env SINGLE_START=camunda-platform-modeler npm run dev",
     "start:cloud": "cross-env SINGLE_START=camunda-cloud-modeler npm run dev",
-    "prepublishOnly": "run-s distro test:distro"
+    "prepublishOnly": "run-s test:distro",
+    "prepare": "run-s distro"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,9 @@
   "license": "MIT",
   "dependencies": {
     "@bpmn-io/align-to-origin": "^0.7.0",
-    "@bpmn-io/properties-panel": "^0.11.0",
     "bpmn-js": "^9.0.2",
     "bpmn-js-disable-collapsed-subprocess": "^0.1.3",
     "bpmn-js-executable-fix": "^0.1.3",
-    "bpmn-js-properties-panel": "~1.0.0-alpha.5",
     "camunda-bpmn-moddle": "^6.1.1",
     "diagram-js": "^8.1.1",
     "diagram-js-minimap": "^2.1.0",
@@ -54,9 +52,11 @@
     "zeebe-bpmn-moddle": "^0.11.0"
   },
   "devDependencies": {
+    "@bpmn-io/properties-panel": "^0.11.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
+    "bpmn-js-properties-panel": "~1.0.0-alpha.5",
     "chai": "^4.2.0",
     "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
@@ -86,5 +86,9 @@
     "sinon": "^9.2.4",
     "sinon-chai": "^3.5.0",
     "webpack": "^5.20.1"
+  },
+  "peerDependencies": {
+    "@bpmn-io/properties-panel": "0.11.x",
+    "bpmn-js-properties-panel": "1.0.0-alpha.5"
   }
 }

--- a/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorIntegrationSpec.js
+++ b/test/camunda-cloud/features/modeling/UpdatePropagateAllChildVariablesBehaviorIntegrationSpec.js
@@ -372,12 +372,19 @@ describe('camunda-cloud/features/modeling - UpdatePropagateAllChildVariablesBeha
 
 // helpers //////////
 
-const getPropagateAllChildVariablesToggle = (container) => {
-  return domQuery('input[name="propagateAllChildVariables"]', container);
+const getPropagateAllChildVariablesToggle = async (container) => {
+  let input;
+  do {
+    await act(() => {
+      input = domQuery('input[name="propagateAllChildVariables"]', container);
+    });
+  } while (!input);
+
+  return input;
 };
 
-const clickPropagateAllChildVariablesToggle = (container) => {
-  const toggle = getPropagateAllChildVariablesToggle(container);
+const clickPropagateAllChildVariablesToggle = async (container) => {
+  const toggle = await getPropagateAllChildVariablesToggle(container);
 
   return act(() => {
     triggerEvent(toggle, 'click');


### PR DESCRIPTION
This is to make sure only one instance of the libraries
is installed even if the project contains extension
and imports `@bpmn-io/properties-panel/preact` or any
of the hooks.

Problem:

When I install both `camunda-bpmn-js` and `bpmn-js-properties-panel` in my project, I may end up with the following structure:

```
├── bpmn-js-properties-panel
├── camunda-bpmn-js
│   ├── node_modules
│   │   ├── bpmn-js-properties-panel
```

As a result, my `useService` import may use different context than the one used in `camunda-bpmn-js` which causes an error.

When we set the peer dependency, `bpmn-js-properties-panel` will be installed only if it's not already present in the project.