### PR TITLE
deps: bump to bpmn-js-properties-panel@1.0.0-alpha.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -906,13 +906,13 @@
       "integrity": "sha512-a8Ri5q2uhCrHJ415BR9ZulajvOw0SX2Eh0jxwoMZ/ynxcZPBbOKm6kW6HAQFJp0EFHwftMiJstcvIcSjyz0hZA=="
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.5.0.tgz",
-      "integrity": "sha512-v/gfuYs7AOsQUzGmWBEupFGZiylCzqapBoZrjavewnPPbDOzLvbHZ1bnYPre/7b/wdnf4ayx0bf/NCC/AEySVg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.6.0.tgz",
+      "integrity": "sha512-GAs/04pjQGJKn02PwSpbmQ83pRBaOobpzVJwnv6dGQ9eg7mI0buBK27SOTNLexWyH+8Cm4NI32piLmkzx2IGVg==",
       "dev": true,
       "requires": {
-        "@camunda/element-templates-json-schema": "^0.7.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.1.0",
+        "@camunda/element-templates-json-schema": "^0.8.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.2.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^3.8.1"
       }
@@ -927,9 +927,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.11.0.tgz",
-      "integrity": "sha512-/1lZiwhCdAsapXKMjzVFc6jdyzU5Ue8wq/mMSFLVvAatxlHHrxTwYAqEW9zA0ZBqIm8JQbl6wptGMG/6ICZPGA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.12.0.tgz",
+      "integrity": "sha512-YAZQQKdWMPQAzS50kZtaHIu5Ik0b/W85OKX4d90HL/xE1Tc9vryTs8SLcFwcPFyYXHPfr/VrI5Rl1341k0MPqg==",
       "dev": true,
       "requires": {
         "classnames": "^2.3.1",
@@ -938,15 +938,15 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
-      "integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.8.0.tgz",
+      "integrity": "sha512-A9VgfJCr9GbDBbws48Ef7zv93pNy1EsjV/ijY0o0R4vUdbzMFbVvTIA+ypAlQC8xmAW1Sj/Gev8ocBM95djnpw==",
       "dev": true
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.1.0.tgz",
-      "integrity": "sha512-E5mie+Q+/0Rk12GerNRWZP6aIWFXo4KfC++6tFJUvKt8la4ZvsPpagB7F8Oiahd56/gUqOicJ7+yPyQ85JnFgA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.2.0.tgz",
+      "integrity": "sha512-2HF/kpcazyxzUBO5gKrhpQ5jvqrqW0wVAAf9ybbOOGhy/uXL+UG749R4OCUstwo1vpoOz5pDTrqOeUJEf7iQ0g==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -2037,12 +2037,12 @@
       "integrity": "sha512-dXvRIUD+NuB/fByFP8r4/Vr8L9Buv/hdRQt0g5wzCHAoF+nW0C/Uv+EjRjwqqFr7AQr1XR+L1ADL3BDyKgeuWw=="
     },
     "bpmn-js-properties-panel": {
-      "version": "1.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.5.tgz",
-      "integrity": "sha512-AXunjjthnApd25M0A0OIVxwIWoJc/BvNVCObf0Ushh86PqESzjAbDkTdtbUGxnj4ukiFJB390K5b5NezUEL5IQ==",
+      "version": "1.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.7.tgz",
+      "integrity": "sha512-RVm2xDSHSgOnBIbtUt8jW44krCB5IIN8/L+cKEWe9A7WZMiXglDw4swem3Wt8LiAvMNL1iFzlmj0v1LHQshtvA==",
       "dev": true,
       "requires": {
-        "@bpmn-io/element-templates-validator": "^0.5.0",
+        "@bpmn-io/element-templates-validator": "^0.6.0",
         "@bpmn-io/extract-process-variables": "^0.4.4",
         "array-move": "^3.0.1",
         "classnames": "^2.3.1",
@@ -2050,7 +2050,7 @@
         "min-dash": "^3.8.1",
         "min-dom": "^3.1.3",
         "preact-markup": "^2.1.1",
-        "semver": "^7.3.5"
+        "semver-compare": "^1.0.0"
       }
     },
     "bpmn-moddle": {
@@ -5967,6 +5967,12 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "zeebe-bpmn-moddle": "^0.11.0"
   },
   "devDependencies": {
-    "@bpmn-io/properties-panel": "^0.11.0",
+    "@bpmn-io/properties-panel": "^0.12.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
-    "bpmn-js-properties-panel": "~1.0.0-alpha.5",
+    "bpmn-js-properties-panel": "~1.0.0-alpha.7",
     "chai": "^4.2.0",
     "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
@@ -89,7 +89,7 @@
     "webpack": "^5.20.1"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": "0.11.x",
-    "bpmn-js-properties-panel": "1.0.0-alpha.5"
+    "@bpmn-io/properties-panel": "0.12.x",
+    "bpmn-js-properties-panel": "1.0.0-alpha.7"
   }
 }

--- a/test/base/ModelerSpec.js
+++ b/test/base/ModelerSpec.js
@@ -56,6 +56,9 @@ insertCSS('test.css', `
 
 describe('<BaseModeler>', function() {
 
+  // CI (windows) takes its time
+  this.timeout(5000);
+
   var modelerContainer;
 
   var propertiesContainer;
@@ -106,6 +109,7 @@ describe('<BaseModeler>', function() {
   }
 
   (singleStart ? it.only : it)('should import simple process', function() {
+
     return createModeler(simpleXml).then(function(result) {
 
       expect(result.error).not.to.exist;

--- a/test/camunda-cloud/ModelerSpec.js
+++ b/test/camunda-cloud/ModelerSpec.js
@@ -56,6 +56,9 @@ insertCSS('test-panel.css', `
 
 describe('<CamundaCloudModeler>', function() {
 
+  // CI (windows) takes its time
+  this.timeout(5000);
+
   var modelerContainer;
 
   var propertiesContainer;

--- a/test/camunda-platform/ModelerSpec.js
+++ b/test/camunda-platform/ModelerSpec.js
@@ -62,6 +62,9 @@ insertCSS('test.css', `
 
 describe('<CamundaPlatformModeler>', function() {
 
+  // CI (windows) takes its time
+  this.timeout(5000);
+
   var modelerContainer;
 
   var propertiesContainer;


### PR DESCRIPTION
This makes the FEEL indicator available (including styles) for camunda-bpmn-js consumers:

![image](https://user-images.githubusercontent.com/58601/159932635-c5768f46-c3f0-4265-a1ed-c1b4c476e92f.png)
