### PR TITLE
chore(CHANGELOG): update to v0.13.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,27 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.13.0-alpha.6
+
+* `FIX`: set $parent when creating zeebe:CalledElement element ([#99](https://github.com/camunda/camunda-bpmn-js/pull/99))
+* `DEPS`: update to `@bpmn-io/properties-panel@0.13.1`
+* `DEPS`: update to `bpmn-js-properties-panel@1.0.0-alpha.9`
+
+# Properties Panel
+
+* `FEAT`: allow showing entries and errors through events ([#137](https://github.com/bpmn-io/properties-panel/pull/137))
+* `FEAT`: allow opening groups per default ([#139](https://github.com/bpmn-io/properties-panel/pull/139))
+* `FEAT`: add documentation ref ([#141](https://github.com/bpmn-io/properties-panel/pull/141))
+* `FEAT`: add show callbacks to show entries and errors ([#601](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/601))
+* `FEAT`: open element template custom groups ([#621](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/621))
+* `FEAT`: display template name in header ([#627](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/627))
+* `FEAT`: add documentation ref to header ([#629](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/629))
+* `FIX`: copy versioned element template ([#632](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/632))
+
 ## 0.13.0-alpha.5
 
 * `DEPS`: update to `@bpmn-io/properties-panel@0.12.0`
-* `DEPS`: update to `bpmn-properties-panel@1.0.0-alpha.7`
+* `DEPS`: update to `bpmn-js-properties-panel@1.0.0-alpha.7`
 
 ## 0.13.0-alpha.4
 
@@ -22,7 +39,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: add cloud element templates ([#95](https://github.com/camunda/camunda-bpmn-js/pull/95))
 * `DEPS`: update to `bpmn-js@9.0.2`
 * `DEPS`: update to `@bpmn-io/properties-panel@0.11.0`
-* `DEPS`: update to `bpmn-properties-panel@1.0.0-alpha.5`
+* `DEPS`: update to `bpmn-js-properties-panel@1.0.0-alpha.5`
 * `DEPS`: update to `zeebe-bpmn-moddle@0.11.0`
 
 ## 0.13.0-alpha.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,23 +918,43 @@
       }
     },
     "@bpmn-io/extract-process-variables": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.4.tgz",
-      "integrity": "sha512-iStnEVSEtOlZoE3ADMImdwhOhxUjXFdwWsCmmJQlyWH5ISmdRvai0Cxuw0spQEYySgIwFsUB0h+ScOCdW6yEBQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.5.tgz",
+      "integrity": "sha512-LtHx5b9xqS8avRLrq/uTlKhWzMeV3bWQKIdDic2bdo5n9roitX13GRb01u2S0hSsKDWEhXQtydFYN2b6G7bqfw==",
       "dev": true,
       "requires": {
-        "min-dash": "^3.5.2"
+        "min-dash": "^3.8.1"
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.12.0.tgz",
-      "integrity": "sha512-YAZQQKdWMPQAzS50kZtaHIu5Ik0b/W85OKX4d90HL/xE1Tc9vryTs8SLcFwcPFyYXHPfr/VrI5Rl1341k0MPqg==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.13.1.tgz",
+      "integrity": "sha512-uN1euwhPGzDnGpMrqYKrrfDD1PESPhUaDnGFA1PqAE8Kd5he6wm2EatAKXkB15Z41xU6qtu3Z+2A86XIFrbCRg==",
       "dev": true,
       "requires": {
         "classnames": "^2.3.1",
+        "diagram-js": "^8.1.2",
         "min-dash": "^3.7.0",
         "min-dom": "^3.1.3"
+      },
+      "dependencies": {
+        "diagram-js": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.2.1.tgz",
+          "integrity": "sha512-R9D4CtRPCXFllGE4P/UTcK3fgYG/0WQfb87Pl7frdfnAbCbjZAM2vU0qgZaBhfU0cmW2OhdDPmEtz89brrOZDA==",
+          "dev": true,
+          "requires": {
+            "css.escape": "^1.5.1",
+            "didi": "^5.2.1",
+            "hammerjs": "^2.0.1",
+            "inherits": "^2.0.4",
+            "min-dash": "^3.5.2",
+            "min-dom": "^3.1.3",
+            "object-refs": "^0.3.0",
+            "path-intersection": "^2.2.1",
+            "tiny-svg": "^2.2.2"
+          }
+        }
       }
     },
     "@camunda/element-templates-json-schema": {
@@ -1013,6 +1033,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
+      }
+    },
+    "@philippfromme/moddle-helpers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@philippfromme/moddle-helpers/-/moddle-helpers-0.4.1.tgz",
+      "integrity": "sha512-6ST9WdafFGh/vxeQP4pwFkcGcqIQJ0mtQSrXwoetTLigCXCcP4UXdXxjcIEwWKoXuexXV/2CgFS0CPENSVcwdg==",
+      "dev": true,
+      "requires": {
+        "min-dash": "^3.8.1"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -2037,13 +2066,14 @@
       "integrity": "sha512-dXvRIUD+NuB/fByFP8r4/Vr8L9Buv/hdRQt0g5wzCHAoF+nW0C/Uv+EjRjwqqFr7AQr1XR+L1ADL3BDyKgeuWw=="
     },
     "bpmn-js-properties-panel": {
-      "version": "1.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.7.tgz",
-      "integrity": "sha512-RVm2xDSHSgOnBIbtUt8jW44krCB5IIN8/L+cKEWe9A7WZMiXglDw4swem3Wt8LiAvMNL1iFzlmj0v1LHQshtvA==",
+      "version": "1.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.10.tgz",
+      "integrity": "sha512-1JCNaIioNP9s5LwZqfIkTGrWzICH3nPxU+cfEIfj87Nc5XOzgz7PCJZpHLgvTsKhbPt/7EnTCCVXGLG8mTX/4A==",
       "dev": true,
       "requires": {
         "@bpmn-io/element-templates-validator": "^0.6.0",
-        "@bpmn-io/extract-process-variables": "^0.4.4",
+        "@bpmn-io/extract-process-variables": "^0.4.5",
+        "@philippfromme/moddle-helpers": "^0.4.1",
         "array-move": "^3.0.1",
         "classnames": "^2.3.1",
         "ids": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "zeebe-bpmn-moddle": "^0.11.0"
   },
   "devDependencies": {
-    "@bpmn-io/properties-panel": "^0.12.0",
+    "@bpmn-io/properties-panel": "^0.13.1",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
-    "bpmn-js-properties-panel": "~1.0.0-alpha.7",
+    "bpmn-js-properties-panel": "^1.0.0-alpha.10",
     "chai": "^4.2.0",
     "cross-env": "^7.0.3",
     "eslint": "^7.32.0",


### PR DESCRIPTION
# Changes

## 0.13.0-alpha.6

* `FIX`: set $parent when creating zeebe:CalledElement element ([#99](https://github.com/camunda/camunda-bpmn-js/pull/99))
* `DEPS`: update to `@bpmn-io/properties-panel@0.13.1`
* `DEPS`: update to `bpmn-js-properties-panel@1.0.0-alpha.9`

# Properties Panel

* `FEAT`: allow showing entries and errors through events ([#137](https://github.com/bpmn-io/properties-panel/pull/137))
* `FEAT`: allow opening groups per default ([#139](https://github.com/bpmn-io/properties-panel/pull/139))
* `FEAT`: add documentation ref ([#141](https://github.com/bpmn-io/properties-panel/pull/141))
* `FEAT`: add show callbacks to show entries and errors ([#601](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/601))
* `FEAT`: open element template custom groups ([#621](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/621))
* `FEAT`: display template name in header ([#627](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/627))
* `FEAT`: add documentation ref to header ([#629](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/629))
* `FIX`: copy versioned element template ([#632](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/632))

---

Required by https://github.com/camunda/camunda-modeler/pull/2861