### PR TITLE
fix: update @bpmn-io/properties-panel peer dependency to match

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "webpack": "^5.20.1"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": "0.15.x",
+    "@bpmn-io/properties-panel": "0.16.x",
     "bpmn-js-properties-panel": "1.x"
   },
   "files": [


### PR DESCRIPTION
`camunda-bpmn-js` and `bpmn-js-properties-panel` both have a peer dependency to `@bpmn-io/properties-panel`, so they need to match. For more context, see https://github.com/bpmn-io/internal-docs/issues/599

Closes #145