### PR TITLE
fix: remove @bpmn-io/properties-panel peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "webpack": "^5.20.1"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": "0.15.x",
     "bpmn-js-properties-panel": "1.x"
   },
   "files": [


### PR DESCRIPTION
* @bpmn-io/properties-panel is transitive peer dependency as it is peer dependency of bpmn-js-properties-panel

---

Related to https://github.com/bpmn-io/internal-docs/issues/599