### PR TITLE
deps: bump property panel dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+* `DEPS`: update to `bpmn-js-properties-panel@1.4.0`
+* `DEPS`: update to `@bpmn-io/properties-panel@0.18.0`
+
+### Key changes in Properties Panel
+
+* `FEAT`: add FEEL editor for FEEL properties ([#158](https://github.com/bpmn-io/properties-panel/pull/158))
+
 ## 0.15.3
 
 * `FIX`: remove `@bpmn-io/properties-panel` peer dependency as it is transitive ([#147](https://github.com/camunda/camunda-bpmn-js/pull/147))

--- a/package-lock.json
+++ b/package-lock.json
@@ -949,20 +949,37 @@
       }
     },
     "@bpmn-io/extract-process-variables": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.5.tgz",
-      "integrity": "sha512-LtHx5b9xqS8avRLrq/uTlKhWzMeV3bWQKIdDic2bdo5n9roitX13GRb01u2S0hSsKDWEhXQtydFYN2b6G7bqfw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.5.0.tgz",
+      "integrity": "sha512-QUkGalROspIF3JmL+7IKYgTj/f66RENniryo/Pl5VGS/4XKSsr+dgi+Y2lJ3el1e68i9w67FyQ7i5604vUAWPQ==",
       "dev": true,
       "requires": {
         "min-dash": "^3.8.1"
       }
     },
-    "@bpmn-io/properties-panel": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.15.0.tgz",
-      "integrity": "sha512-9HDgqFKsmv0gavZzWZmUKEY2bJA/M/+5TubGU2DmjQ5cJY9nTTfxcKBtM5/wFwHtd6AAfYy9tF2KGUp1RPVuTA==",
+    "@bpmn-io/feel-editor": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.2.0.tgz",
+      "integrity": "sha512-R85p56nFxffNp0fStNxz561EXJmcTdVZL7NyVhuB3qKS/mt4thuvK1B43YnXKdLx8WessjsbHzjvWkbCYZRWkQ==",
       "dev": true,
       "requires": {
+        "@codemirror/autocomplete": "^6.0.3",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "lezer-feel": "^0.4.0"
+      }
+    },
+    "@bpmn-io/properties-panel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.18.0.tgz",
+      "integrity": "sha512-2OCc6QplFKlCG8hmsAuUvd0JJTPjGvTJ6zxO73R9TpnUw7PKsXq2oIJjJfWsNdmvpmkxeyHoklOf5XpQXFjygw==",
+      "dev": true,
+      "requires": {
+        "@bpmn-io/feel-editor": "0.2.0",
         "classnames": "^2.3.1",
         "diagram-js": "^8.1.2",
         "min-dash": "^3.7.0",
@@ -980,6 +997,72 @@
       "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.5.0.tgz",
       "integrity": "sha512-BVHVl4cuK9LxL1eDSdWs8AzuZd981/+CPkw7xlwcB1Xkn6Di8E2iRbDUCBhOIqkahjJYq957nVtbM6jlqXX5qw==",
       "dev": true
+    },
+    "@codemirror/autocomplete": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz",
+      "integrity": "sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==",
+      "dev": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@codemirror/commands": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.0.1.tgz",
+      "integrity": "sha512-iNHDByicYqQjs0Wo1MKGfqNbMYMyhS9WV6EwMVwsHXImlFemgEUC+c5X22bXKBStN3qnwg4fArNZM+gkv22baQ==",
+      "dev": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@codemirror/language": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "@codemirror/lint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "@codemirror/state": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.0.tgz",
+      "integrity": "sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg==",
+      "dev": true
+    },
+    "@codemirror/view": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.1.2.tgz",
+      "integrity": "sha512-puUydfKwfmOo+ixtuB+uN/ZpcteEYSnpjHmMaow1sOQhNICsKtGBup3i9ybVqyzDagARRYzSHTWjbdeHqmn31w==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -1021,6 +1104,30 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@lezer/common": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.0.tgz",
+      "integrity": "sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA==",
+      "dev": true
+    },
+    "@lezer/highlight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
+      "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@lezer/lr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.0.tgz",
+      "integrity": "sha512-TgEpfm9br2SX8JwtwKT8HsQZKuFkLRg6g+IRxObk9nVKQLKnkP3oMh+QGcTBL9GQsfQ2ADtKPbj2iGSMf3ytiA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -1045,15 +1152,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
-      }
-    },
-    "@philippfromme/moddle-helpers": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@philippfromme/moddle-helpers/-/moddle-helpers-0.4.1.tgz",
-      "integrity": "sha512-6ST9WdafFGh/vxeQP4pwFkcGcqIQJ0mtQSrXwoetTLigCXCcP4UXdXxjcIEwWKoXuexXV/2CgFS0CPENSVcwdg==",
-      "dev": true,
-      "requires": {
-        "min-dash": "^3.8.1"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -2088,14 +2186,13 @@
       "integrity": "sha512-dXvRIUD+NuB/fByFP8r4/Vr8L9Buv/hdRQt0g5wzCHAoF+nW0C/Uv+EjRjwqqFr7AQr1XR+L1ADL3BDyKgeuWw=="
     },
     "bpmn-js-properties-panel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.2.0.tgz",
-      "integrity": "sha512-AdDZlhDZ/HEl17sohD+ffaUdr4HvoyLMhIsuaeqrWsHWx9FHtF8bSB0erRHC1b0SfBdLXYPNxcr9ql3oGtJmMA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.4.0.tgz",
+      "integrity": "sha512-+15Yg7FohrdpDuKqegxU9OyGgYcH6sZM06DjwBLKrpqHgmXEXMA0yD0UI9Rc95P4mRfsT4rAzGpZjYnsYgOshg==",
       "dev": true,
       "requires": {
         "@bpmn-io/element-templates-validator": "^0.9.0",
-        "@bpmn-io/extract-process-variables": "^0.4.5",
-        "@philippfromme/moddle-helpers": "^0.4.1",
+        "@bpmn-io/extract-process-variables": "^0.5.0",
         "array-move": "^3.0.1",
         "classnames": "^2.3.1",
         "ids": "^1.0.0",
@@ -7355,6 +7452,12 @@
         "vary": "^1"
       }
     },
+    "crelt": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
+      "dev": true
+    },
     "cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -9348,6 +9451,32 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lezer-feel": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.4.0.tgz",
+      "integrity": "sha512-yd+AWsOE4NGVeW4x50HXUA9dKs9MUa7H8PATPNEmBiXKfIijPlC6+FEy8OLjOzb4b9y9pPPpAqnZ2/kvLmvZVw==",
+      "dev": true,
+      "requires": {
+        "@lezer/lr": "^0.16.0"
+      },
+      "dependencies": {
+        "@lezer/common": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
+          "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
+          "dev": true
+        },
+        "@lezer/lr": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
+          "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
+          "dev": true,
+          "requires": {
+            "@lezer/common": "^0.16.0"
+          }
+        }
       }
     },
     "lines-and-columns": {
@@ -11734,6 +11863,12 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "style-mod": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -12064,6 +12199,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "w3c-keyname": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.5.tgz",
+      "integrity": "sha512-WJrK7i6w+ULuZsGscCezbCH4Aev5U3xY87vnSimzzEgPQhb0Sa0a1rE3c2jtEwrFtSfi61Jefw3jI5/DD/3jbQ==",
       "dev": true
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
   },
   "devDependencies": {
     "@bpmn-io/element-template-chooser": "0.0.5",
-    "@bpmn-io/properties-panel": "^0.15.0",
+    "@bpmn-io/properties-panel": "^0.18.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
-    "bpmn-js-properties-panel": "^1.2.0",
+    "bpmn-js-properties-panel": "^1.4.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.3",
     "del-cli": "^4.0.1",


### PR DESCRIPTION
This adds the FEEL editor to the Properties panel. Event though it is a peer dependency, it is required for updated style sheets in the downstream projects.

try it out with `npm run start:cloud`

![Recording 2022-08-02 at 16 33 18 (1)](https://user-images.githubusercontent.com/21984219/182400615-a330a5f1-0f35-48d1-9f81-dd97befae5b9.gif)
