### PR TITLE
deps: update bpmn-js-properties-panel peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "webpack": "^5.20.1"
       },
       "peerDependencies": {
-        "bpmn-js-properties-panel": "1.x"
+        "bpmn-js-properties-panel": "^1.7.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "webpack": "^5.20.1"
   },
   "peerDependencies": {
-    "bpmn-js-properties-panel": "1.x"
+    "bpmn-js-properties-panel": "^1.7.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
We want to ensure people are using at least `v1.7.0`.