### PR TITLE
chore(CHANGELOG): update to v0.22.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-latest, ubuntu-20.04, windows-latest ]
         node-version: [ 16 ]
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.22.0
+
+* `FEAT`: cloud modeler allows modeling of all elements ([#196](https://github.com/camunda/camunda-bpmn-js/pull/196))
+* `DEPS`: update to `diagram-js@10`
+
+### Breaking Changes
+
+* cloud modeler allows modeling of elements not supported by the engine; use [`@camunda/linting`](https://github.com/camunda/linting) to indicate elements supported by engine
+
 ## 0.21.1
 
 * `FIX`: remove _Cycle_ option of _Timer_ _Type_ of interrupting timer start event ([#802](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/802))


### PR DESCRIPTION
# Changes

* `FEAT`: cloud modeler allows modeling of all elements ([#196](https://github.com/camunda/camunda-bpmn-js/pull/196))
* `DEPS`: update to `diagram-js@10`

### Breaking Changes

* cloud modeler allows modeling of elements not supported by the engine; use [`@camunda/linting`](https://github.com/camunda/linting) to indicate elements supported by engine