### PR TITLE
ci: run with coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,16 +29,16 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Build
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-20.04'
       env:
         COVERAGE: 1
         TEST_BROWSERS: Firefox,ChromeHeadless
       run: xvfb-run npm run all
     - name: Build
-      if: matrix.os != 'ubuntu-latest'
+      if: matrix.os != 'ubuntu-20.04'
       env:
         TEST_BROWSERS: ChromeHeadless
       run: npm run all
     - name: Upload Coverage
       uses: codecov/codecov-action@v3
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-20.04'


### PR DESCRIPTION
This was broken with commit bc39e6bc224be61e730edb4ca63019698cdcedbe, where we only changed the os but not all references to it