### PR TITLE
deps: update diagram-js-minimap to v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: minimap works with touch ([#54](https://github.com/bpmn-io/diagram-js-minimap/pull/54))
+* `DEPS`: update to `diagram-js-minimap@4.0.1`
+
 ## 1.1.2
 
 * `DEPS`: update to `bpmn-js-properties-panel@1.15.1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "camunda-bpmn-js-behaviors": "^0.4.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "diagram-js": "^11.4.4",
-        "diagram-js-minimap": "^3.0.0",
+        "diagram-js-minimap": "^4.0.1",
         "diagram-js-origin": "^1.4.0",
         "inherits-browser": "^0.1.0",
         "min-dash": "^4.0.0",
@@ -3122,11 +3122,12 @@
       }
     },
     "node_modules/diagram-js-minimap": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-3.0.0.tgz",
-      "integrity": "sha512-ntjlGZpfnlkBS8YpMD8mwUETtA4NijVP8Wxh+4/FLEVhqYZw1fO8SpoSEOLjievCfkJwmN49FME0wa/fqz5qzA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-4.0.1.tgz",
+      "integrity": "sha512-CPq9DModYVZfZd/34YD386y/nO2G5PNGexTnvSXNtprqXm/WYWkMsJZwuOrNNmSm2OWH5YH2ju1LbQmkqUDbZQ==",
       "dependencies": {
         "css.escape": "^1.5.1",
+        "hammerjs": "^2.0.8",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.2",
         "tiny-svg": "^3.0.0"
@@ -12151,11 +12152,12 @@
       }
     },
     "diagram-js-minimap": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-3.0.0.tgz",
-      "integrity": "sha512-ntjlGZpfnlkBS8YpMD8mwUETtA4NijVP8Wxh+4/FLEVhqYZw1fO8SpoSEOLjievCfkJwmN49FME0wa/fqz5qzA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-4.0.1.tgz",
+      "integrity": "sha512-CPq9DModYVZfZd/34YD386y/nO2G5PNGexTnvSXNtprqXm/WYWkMsJZwuOrNNmSm2OWH5YH2ju1LbQmkqUDbZQ==",
       "requires": {
         "css.escape": "^1.5.1",
+        "hammerjs": "^2.0.8",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.2",
         "tiny-svg": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "camunda-bpmn-js-behaviors": "^0.4.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "diagram-js": "^11.4.4",
-    "diagram-js-minimap": "^3.0.0",
+    "diagram-js-minimap": "^4.0.1",
     "diagram-js-origin": "^1.4.0",
     "inherits-browser": "^0.1.0",
     "min-dash": "^4.0.0",


### PR DESCRIPTION
Adds touch support to the minimap (cf. https://github.com/bpmn-io/diagram-js-minimap/pull/54).