### PR TITLE
fix(platform): add create/append menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.1.1
+
+* `FIX`: add create and append menus to platform modeler ([#268](https://github.com/camunda/camunda-bpmn-js/pull/268))
+
 ## 2.1.0
 
 * `DEPS`: add `@camunda/example-data-properties-provider@1.0.1`

--- a/lib/camunda-platform/Modeler.js
+++ b/lib/camunda-platform/Modeler.js
@@ -18,6 +18,7 @@ import { commonModdleExtensions } from './util/commonModules';
 import colorPickerModule from 'bpmn-js-color-picker';
 
 import {
+  CreateAppendAnythingModule as createAppendAnythingModule,
   UnlinkTemplatesModule as unlinkTemplatesModule
 } from 'bpmn-js-create-append-anything';
 
@@ -46,6 +47,7 @@ Modeler.prototype._camundaPlatformModules = [
   CamundaPlatformPropertiesProviderModule,
   ElementTemplatesPropertiesProviderModule,
   colorPickerModule,
+  createAppendAnythingModule,
   variableResolverModule,
   unlinkTemplatesModule
 ];


### PR DESCRIPTION
Adds the create/append menus back to the platform modeler (without the element templates) -> current behaviour in desktop modeler that was broken when we migrated to using the `bpmn-js-create-append-anything` extension