### PR TITLE
Prepare 2.6.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.6.1
+
+* `DEPS`: update to `@bpmn-io/element-template-icon-renderer@0.5.1`
+
+### Key changes in Modeling
+
+* `FIX`: intermediate catch and throw events with icons render successfully ([bpmn-io/element-template-icon-renderer#16](https://github.com/bpmn-io/element-template-icon-renderer/pull/16))
+
 ## 2.6.0
 
 * `DEPS`: update to `bpmn-js-properties-panel@1.26.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bpmn-io/align-to-origin": "^0.7.0",
         "@bpmn-io/element-template-chooser": "^1.0.0",
-        "@bpmn-io/element-template-icon-renderer": "^0.5.0",
+        "@bpmn-io/element-template-icon-renderer": "^0.5.1",
         "@bpmn-io/variable-resolver": "^1.1.0",
         "@camunda/example-data-properties-provider": "^1.1.1",
         "bpmn-js": "^13.1.0",
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@bpmn-io/element-template-icon-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-icon-renderer/-/element-template-icon-renderer-0.5.0.tgz",
-      "integrity": "sha512-UH2P1phxx6G02BTvdOHLGX6hJrPs16Rv0d89uJmx87j+2MNu6Qhj4oO0L4lcbeD9QMc77/w4ZMYe6zjMaDN9UA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-icon-renderer/-/element-template-icon-renderer-0.5.1.tgz",
+      "integrity": "sha512-sdvMZ1trMw5QVN6YQFUpZ4ck5XNeibY17tT5isVlJT2+OxEy9ssxRFscmPAgnWyMakpmsO12soa1IsyC1+xyEg==",
       "dependencies": {
         "inherits-browser": "^0.1.0",
         "tiny-svg": "^3.0.1"
@@ -13653,9 +13653,9 @@
       "requires": {}
     },
     "@bpmn-io/element-template-icon-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-icon-renderer/-/element-template-icon-renderer-0.5.0.tgz",
-      "integrity": "sha512-UH2P1phxx6G02BTvdOHLGX6hJrPs16Rv0d89uJmx87j+2MNu6Qhj4oO0L4lcbeD9QMc77/w4ZMYe6zjMaDN9UA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-template-icon-renderer/-/element-template-icon-renderer-0.5.1.tgz",
+      "integrity": "sha512-sdvMZ1trMw5QVN6YQFUpZ4ck5XNeibY17tT5isVlJT2+OxEy9ssxRFscmPAgnWyMakpmsO12soa1IsyC1+xyEg==",
       "requires": {
         "inherits-browser": "^0.1.0",
         "tiny-svg": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@bpmn-io/align-to-origin": "^0.7.0",
     "@bpmn-io/element-template-chooser": "^1.0.0",
-    "@bpmn-io/element-template-icon-renderer": "^0.5.0",
+    "@bpmn-io/element-template-icon-renderer": "^0.5.1",
     "@bpmn-io/variable-resolver": "^1.1.0",
     "@camunda/example-data-properties-provider": "^1.1.1",
     "bpmn-js": "^13.1.0",


### PR DESCRIPTION
* update @bpmn-io/element-template-icon-renderer to v0.5.1
* update CHANGELOG

---

Related to https://github.com/camunda/web-modeler/issues/4879