### PR TITLE
chore(build): use `properties-panel.css` from `@bpmn-io/properties-panel`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-loader": "^9.0.0",
         "babel-plugin-istanbul": "^6.1.1",
         "bio-dts": "^0.8.1",
-        "bpmn-js-properties-panel": "^4.0.2",
+        "bpmn-js-properties-panel": "^5.0.0",
         "chai": "^4.3.7",
         "cross-env": "^7.0.3",
         "del-cli": "^5.0.0",
@@ -2589,9 +2589,9 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-4.0.2.tgz",
-      "integrity": "sha512-UhMRmXcmcDb7EvLHe7qvWGLEUsRmNn1m8mz4/1keonWFnvTy4HAblg+CecORc/tGtSBEI1CsrrPwA5qPZsHn0Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.0.0.tgz",
+      "integrity": "sha512-lH8GYCMqnzRvaTvQLRsmFhN8oYDVkcUG1Il1Xq2tUoIW0huv9q6Yj5Tuy8nwxpCRAy0G0kNpVqR1JC60/uVFNA==",
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^0.14.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
@@ -15769,9 +15769,9 @@
       "requires": {}
     },
     "bpmn-js-properties-panel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-4.0.2.tgz",
-      "integrity": "sha512-UhMRmXcmcDb7EvLHe7qvWGLEUsRmNn1m8mz4/1keonWFnvTy4HAblg+CecORc/tGtSBEI1CsrrPwA5qPZsHn0Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.0.0.tgz",
+      "integrity": "sha512-lH8GYCMqnzRvaTvQLRsmFhN8oYDVkcUG1Il1Xq2tUoIW0huv9q6Yj5Tuy8nwxpCRAy0G0kNpVqR1JC60/uVFNA==",
       "requires": {
         "@bpmn-io/element-templates-validator": "^0.14.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "babel-loader": "^9.0.0",
     "babel-plugin-istanbul": "^6.1.1",
     "bio-dts": "^0.8.1",
-    "bpmn-js-properties-panel": "^4.0.2",
+    "bpmn-js-properties-panel": "^5.0.0",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",
     "del-cli": "^5.0.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,7 +52,7 @@ const styles = [
     dest: 'dist/assets'
   },
   {
-    src: resolve('bpmn-js-properties-panel', '/dist/assets/properties-panel.css'),
+    src: resolve('@bpmn-io/properties-panel', '/assets/properties-panel.css'),
     dest: 'dist/assets'
   },
   {

--- a/test/base/ModelerSpec.js
+++ b/test/base/ModelerSpec.js
@@ -14,7 +14,7 @@ import Modeler from 'lib/base/Modeler';
 
 import simpleXml from 'test/fixtures/simple.bpmn';
 
-import propertiesPanelCSS from 'bpmn-js-properties-panel/dist/assets/properties-panel.css';
+import propertiesPanelCSS from '@bpmn-io/properties-panel/assets/properties-panel.css';
 
 var singleStart = window.__env__ && window.__env__.SINGLE_START === 'base-modeler';
 

--- a/test/camunda-cloud/ModelerSpec.js
+++ b/test/camunda-cloud/ModelerSpec.js
@@ -16,7 +16,7 @@ import diagramXml from './ModelerSpec.simple.bpmn';
 
 import simpleXml from 'test/fixtures/simple.bpmn';
 
-import propertiesPanelCSS from 'bpmn-js-properties-panel/dist/assets/properties-panel.css';
+import propertiesPanelCSS from '@bpmn-io/properties-panel/assets/properties-panel.css';
 import elementTemplatesCSS from 'bpmn-js-element-templates/dist/assets/element-templates.css';
 import colorPickerCSS from 'bpmn-js-color-picker/colors/color-picker.css';
 

--- a/test/camunda-platform/ModelerSpec.js
+++ b/test/camunda-platform/ModelerSpec.js
@@ -14,7 +14,7 @@ import Modeler from 'lib/camunda-platform/Modeler';
 
 import simpleXml from 'test/fixtures/simple.bpmn';
 
-import propertiesPanelCSS from 'bpmn-js-properties-panel/dist/assets/properties-panel.css';
+import propertiesPanelCSS from '@bpmn-io/properties-panel/assets/properties-panel.css';
 import elementTemplatesCSS from 'bpmn-js-element-templates/dist/assets/element-templates.css';
 
 import elementTemplatesChooserCSS from '@bpmn-io/element-template-chooser/dist/element-template-chooser.css';


### PR DESCRIPTION
This also fixes the css issue with the latest properties-panel release

![image](https://github.com/camunda/camunda-bpmn-js/assets/21984219/94588ba1-6e4f-4158-9ea9-26dfb15fa30c)
