### PR TITLE
deps: update to `bpmn-js-element-templates@1.9.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.10.2
+
+### Key Changes in Element Templates
+
+* `FIX`: keep custom value on update when the condition was changed ([bpmn-js-element-templates#32](https://github.com/bpmn-io/bpmn-js-element-templates/issues/32))
+* `DEPS`: update to `bpmn-js-element-templates@1.9.2`
+
 ## 3.10.1
 
 * `FIX`: remove unneeded `camunda-cloud` rules ([#325](https://github.com/camunda/camunda-bpmn-js/pull/325))

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "bpmn-js": "^15.2.2",
         "bpmn-js-color-picker": "^0.6.1",
         "bpmn-js-create-append-anything": "^0.4.0",
-        "bpmn-js-element-templates": "^1.9.1",
+        "bpmn-js-element-templates": "^1.9.2",
         "bpmn-js-executable-fix": "^0.2.1",
         "camunda-bpmn-js-behaviors": "^1.2.2",
         "camunda-bpmn-moddle": "^7.0.1",
@@ -4758,9 +4758,9 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.9.1.tgz",
-      "integrity": "sha512-/j65sPHxmkpRTXnhzIrdvThdXr4hDMlsJzOY1eq3NeSe1docV+GQDUo0pfNPdbUuQqePvqOdBrP6oTdhCHm/0A==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.9.2.tgz",
+      "integrity": "sha512-O1ic/VwLM4yfE5eG9DbKiyFr8x3LA3NYrAofBtIjni98veIiEnP7m92gRxopRWh8f1043/uDoqLQ4MUN5CF2gg==",
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^1.6.1",
         "@bpmn-io/extract-process-variables": "^0.8.0",
@@ -21643,9 +21643,9 @@
       }
     },
     "bpmn-js-element-templates": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.9.1.tgz",
-      "integrity": "sha512-/j65sPHxmkpRTXnhzIrdvThdXr4hDMlsJzOY1eq3NeSe1docV+GQDUo0pfNPdbUuQqePvqOdBrP6oTdhCHm/0A==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.9.2.tgz",
+      "integrity": "sha512-O1ic/VwLM4yfE5eG9DbKiyFr8x3LA3NYrAofBtIjni98veIiEnP7m92gRxopRWh8f1043/uDoqLQ4MUN5CF2gg==",
       "requires": {
         "@bpmn-io/element-templates-validator": "^1.6.1",
         "@bpmn-io/extract-process-variables": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bpmn-js": "^15.2.2",
     "bpmn-js-color-picker": "^0.6.1",
     "bpmn-js-create-append-anything": "^0.4.0",
-    "bpmn-js-element-templates": "^1.9.1",
+    "bpmn-js-element-templates": "^1.9.2",
     "bpmn-js-executable-fix": "^0.2.1",
     "camunda-bpmn-js-behaviors": "^1.2.2",
     "camunda-bpmn-moddle": "^7.0.1",


### PR DESCRIPTION
Would be cool to get this into the 5.18 release