### PR TITLE
deps: update to bpmn-js-element-templates@1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 4.0.1
+
+* `DEPS`: update to `lezer-feel@1.2.6`
+* `DEPS`: update to `bpmn-js-element-templates@1.13.2`
+
+### Key Changes in Element Templates
+* `FIX`: apply all chained conditional properties ([bpmn-js-element-templates#49](https://github.com/bpmn-io/bpmn-js-element-templates/issues/49))
+
+### Key Changes in Properties Panel
+* `FIX`: adjust FEEL parsing to accept certain broken expressions ([camunda-modeler#4073](https://github.com/camunda/camunda-modeler/issues/4073))
+
 ## 4.0.0
 
 * `FEAT`: add to selection through SHIFT ([bpmn-io/diagram-js#796](https://github.com/bpmn-io/diagram-js/pull/851), [#2053](https://github.com/bpmn-io/bpmn-js/issues/2053))

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "bpmn-js": "^17.0.0",
         "bpmn-js-color-picker": "^0.7.0",
         "bpmn-js-create-append-anything": "^0.5.0",
-        "bpmn-js-element-templates": "^1.13.1",
+        "bpmn-js-element-templates": "^1.13.2",
         "bpmn-js-executable-fix": "^0.2.1",
         "camunda-bpmn-js-behaviors": "^1.2.3",
         "camunda-bpmn-moddle": "^7.0.1",
@@ -3154,9 +3154,9 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.13.1.tgz",
-      "integrity": "sha512-VRA3LnC4tSiciWvJvm05fGFt0fsHtIhAVWahfw071ZSdbcWHnH2FHbmkZTLWYpi4z1Ayrub6TxTW0Fim9tcRFw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.13.2.tgz",
+      "integrity": "sha512-/W1W9rW3e2gY1ePMet6hcQK6uMlobUDmXIlFiSxXPMA7aUytb0jm2kH9NaaNBKoQCEvTuZ72OUKEKt+ZMiLcvA==",
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^1.7.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
@@ -18413,9 +18413,9 @@
       }
     },
     "bpmn-js-element-templates": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.13.1.tgz",
-      "integrity": "sha512-VRA3LnC4tSiciWvJvm05fGFt0fsHtIhAVWahfw071ZSdbcWHnH2FHbmkZTLWYpi4z1Ayrub6TxTW0Fim9tcRFw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.13.2.tgz",
+      "integrity": "sha512-/W1W9rW3e2gY1ePMet6hcQK6uMlobUDmXIlFiSxXPMA7aUytb0jm2kH9NaaNBKoQCEvTuZ72OUKEKt+ZMiLcvA==",
       "requires": {
         "@bpmn-io/element-templates-validator": "^1.7.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bpmn-js": "^17.0.0",
     "bpmn-js-color-picker": "^0.7.0",
     "bpmn-js-create-append-anything": "^0.5.0",
-    "bpmn-js-element-templates": "^1.13.1",
+    "bpmn-js-element-templates": "^1.13.2",
     "bpmn-js-executable-fix": "^0.2.1",
     "camunda-bpmn-js-behaviors": "^1.2.3",
     "camunda-bpmn-moddle": "^7.0.1",


### PR DESCRIPTION
Let's release a patch that includes the 2 small (but impactful) fixes so web modeler can eagerly integrate them.
Desktop modeler will ship them with the next monthly release