### PR TITLE
fix: use distinct groups for replacement with resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.7.1
+
+### Key Changes in Modeling
+
+* `FIX`: use distinct groups for replacement with resource
+
 ## 5.7.0
 
 * `DEPS`: update to `bpmn-js-properties-panel@5.35.0`

--- a/lib/camunda-cloud/features/external-resources/handlers/util/BaseReplaceMenuProvider.js
+++ b/lib/camunda-cloud/features/external-resources/handlers/util/BaseReplaceMenuProvider.js
@@ -69,6 +69,7 @@ export class BaseReplaceMenuProvider {
         label: resource.name,
         action: replace,
         group: {
+          id: groupName.toLowerCase(),
           name: this._translate(groupName)
         },
         className,

--- a/test/camunda-cloud/features/external-resources/ResourcesSpec.js
+++ b/test/camunda-cloud/features/external-resources/ResourcesSpec.js
@@ -28,6 +28,12 @@ import { ResourcesModule, DefaultHandlersModule } from 'lib/camunda-cloud/featur
 import diagramXML from './Resources.bpmn';
 import resourcesJSON from '../../resources.json';
 
+const TYPE_TO_GROUP_ID = {
+  bpmnProcess: 'processes',
+  dmnDecision: 'decisions',
+  form: 'forms'
+};
+
 
 describe('camunda-cloud/features/external-resources - Resources', function() {
 
@@ -64,6 +70,26 @@ describe('camunda-cloud/features/external-resources - Resources', function() {
       // then
       for (const resource of resourcesJSON) {
         expect(entries[`resources-create-${resource.type}-0`], `<create-${resource.type}> to exist`).to.exist;
+      }
+    }));
+
+
+    it('should group entries according to resource type', inject(function(elementRegistry, resources) {
+
+      // given
+      resources.set(resourcesJSON);
+      const task = elementRegistry.get('TASK');
+
+      // when
+      const {
+        entries
+      } = openPopup(task, 'bpmn-create');
+
+      // then
+      for (const resource of resourcesJSON) {
+        const entry = entries[`resources-create-${resource.type}-0`];
+
+        expect(entry.group.id).to.eql(TYPE_TO_GROUP_ID[resource.type]);
       }
     }));
 
@@ -152,6 +178,26 @@ describe('camunda-cloud/features/external-resources - Resources', function() {
     }));
 
 
+    it('should group entries according to resource type', inject(function(elementRegistry, resources) {
+
+      // given
+      resources.set(resourcesJSON);
+      const task = elementRegistry.get('TASK');
+
+      // when
+      const {
+        entries
+      } = openPopup(task, 'bpmn-append');
+
+      // then
+      for (const resource of resourcesJSON) {
+        const entry = entries[`resources-append-${resource.type}-0`];
+
+        expect(entry.group.id).to.eql(TYPE_TO_GROUP_ID[resource.type]);
+      }
+    }));
+
+
     it('should append call activity', inject(function(elementRegistry, resources) {
 
       // given
@@ -234,7 +280,27 @@ describe('camunda-cloud/features/external-resources - Resources', function() {
 
       // then
       for (const resource of resourcesJSON) {
-        expect(entries[`resources-replace-${resource.type}-0`], `<append-${resource.type}> to exist`).to.exist;
+        expect(entries[`resources-replace-${resource.type}-0`], `<replace-${resource.type}> to exist`).to.exist;
+      }
+    }));
+
+
+    it('should group entries according to resource type', inject(function(elementRegistry, resources) {
+
+      // given
+      resources.set(resourcesJSON);
+      const task = elementRegistry.get('TASK');
+
+      // when
+      const {
+        entries
+      } = openPopup(task, 'bpmn-replace');
+
+      // then
+      for (const resource of resourcesJSON) {
+        const entry = entries[`resources-replace-${resource.type}-0`];
+
+        expect(entry.group.id).to.eql(TYPE_TO_GROUP_ID[resource.type]);
       }
     }));
 


### PR DESCRIPTION
### Proposed Changes

This PR makes sure that we provide group ids for all resources popup menus, including replacement where this was missing.

![image](https://github.com/user-attachments/assets/c6ffe519-0a26-4bd1-b693-27b31af2e14a)


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
