### PR TITLE
deps: update to `camunda-bpmn-js-behaviors@1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.9.0
+
+* `DEPS`: update to `camunda-bpmn-js-behaviors@1.10.0`
+
+### Key Changes in Modeling
+
+* `FEAT`: remove message ref when replacing with send task or throw event
+
 ## 5.8.0
 
 * `DEPS`: update to `bpmn-js@18.6.1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "bpmn-js-create-append-anything": "^1.0.0",
         "bpmn-js-element-templates": "^2.5.3",
         "bpmn-js-executable-fix": "^0.2.1",
-        "camunda-bpmn-js-behaviors": "^1.9.1",
+        "camunda-bpmn-js-behaviors": "^1.10.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "diagram-js": "^15.3.0",
         "diagram-js-grid": "^1.1.0",
@@ -3544,9 +3544,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.9.1.tgz",
-      "integrity": "sha512-VHTJFgfsqn9C4ass4irNr9rQkrqBzNmw4+/l0yh8CW34XciIBDa754ZVmDpE5h86Ffl+yeiySbUaH/PqeoNWOw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.0.tgz",
+      "integrity": "sha512-WQ4S/IcNjtRSZrEzhI9r1mk+57y0PAAZ+Xz/a5srGaCWv8dNHyXk66YRZDaomFSc67jS6toFO2HpQX9S0ZdQFQ==",
       "license": "MIT",
       "dependencies": {
         "ids": "^1.0.0",
@@ -16979,9 +16979,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.9.1.tgz",
-      "integrity": "sha512-VHTJFgfsqn9C4ass4irNr9rQkrqBzNmw4+/l0yh8CW34XciIBDa754ZVmDpE5h86Ffl+yeiySbUaH/PqeoNWOw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.0.tgz",
+      "integrity": "sha512-WQ4S/IcNjtRSZrEzhI9r1mk+57y0PAAZ+Xz/a5srGaCWv8dNHyXk66YRZDaomFSc67jS6toFO2HpQX9S0ZdQFQ==",
       "requires": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bpmn-js-create-append-anything": "^1.0.0",
     "bpmn-js-element-templates": "^2.5.3",
     "bpmn-js-executable-fix": "^0.2.1",
-    "camunda-bpmn-js-behaviors": "^1.9.1",
+    "camunda-bpmn-js-behaviors": "^1.10.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "diagram-js": "^15.3.0",
     "diagram-js-grid": "^1.1.0",


### PR DESCRIPTION
### Proposed Changes

This PR incorporates camunda-bpmn-js-behaviors@1.10.0. Message ref is not supported for throw events and send task in Camunda 8.

https://github.com/user-attachments/assets/db6fcb5c-3d5e-4b95-b6a3-630abc728638

Related to https://github.com/camunda/camunda-modeler/issues/5003

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
