### PR TITLE
fix: describe the remove-template entry in the replace menu

### DIFF
--- a/lib/base/features/element-descriptions/DescriptionProvider.js
+++ b/lib/base/features/element-descriptions/DescriptionProvider.js
@@ -8,6 +8,9 @@
  * except in compliance with the MIT License.
  */
 
+import * as ReplaceOptions from 'bpmn-js/lib/features/replace/ReplaceOptions';
+import { isDifferentType } from 'bpmn-js/lib/features/popup-menu/util/TypeUtil';
+
 import { ELEMENT_DESCRIPTIONS } from './descriptions';
 
 import { mapPopupEntries } from '../../../util/PopupMenuEntriesUtil';
@@ -40,6 +43,31 @@ function toElementId(entryId) {
   return ACTION_TO_ELEMENT[id] || id;
 }
 
+// The "remove template" entry uses a single fixed id (no element type in it), so
+// unlike the other entries its description can't be derived from the id. It reverts
+// the element to its plain type, so we describe it as that type.
+const REMOVE_TEMPLATE_ENTRY = 'replace-remove-element-template';
+
+// Resolve the plain type's description id from the element's matching replace
+// option, keeping it in sync with the regular `replace-with-*` entries.
+function toElementIdFromType(element) {
+  const differentType = isDifferentType(element);
+
+  for (const options of Object.values(ReplaceOptions)) {
+    if (!Array.isArray(options)) {
+      continue;
+    }
+
+    const sameType = options.find(option => option.target && !differentType(option));
+
+    if (sameType) {
+      return toElementId(sameType.actionName);
+    }
+  }
+
+  return null;
+}
+
 /**
  * Adds plain-language descriptions to the create, append and replace menus.
  *
@@ -57,11 +85,13 @@ export default function DescriptionProvider(popupMenu, translate) {
 
 DescriptionProvider.$inject = [ 'popupMenu', 'translate' ];
 
-DescriptionProvider.prototype.getPopupMenuEntries = function() {
+DescriptionProvider.prototype.getPopupMenuEntries = function(element) {
   const translate = this._translate;
 
   return (entries) => mapPopupEntries(entries, (entry, id) => {
-    const description = ELEMENT_DESCRIPTIONS[toElementId(id)];
+    const elementId = id === REMOVE_TEMPLATE_ENTRY ? toElementIdFromType(element) : toElementId(id);
+
+    const description = ELEMENT_DESCRIPTIONS[elementId];
 
     return description ? { ...entry, description: translate(description) } : entry;
   });

--- a/test/camunda-cloud/features/element-descriptions/ElementDescriptionsSpec.js
+++ b/test/camunda-cloud/features/element-descriptions/ElementDescriptionsSpec.js
@@ -122,6 +122,29 @@ describe('camunda-cloud/features/element-descriptions', function() {
     expect(findEntry(entries, 'append-user-task').description).to.eql(ELEMENT_DESCRIPTIONS['user-task']);
   }));
 
+
+  it('should describe the remove-template replace entry as the element plain type', inject(
+    function(elementRegistry, popupMenu) {
+
+      // given a provider contributes the generic remove-template entry
+      // (create-append's RemoveTemplateReplaceProvider) before descriptions run
+      popupMenu.registerProvider('bpmn-replace', 600, {
+        getPopupMenuEntries: () => (entries) => ({
+          ...entries,
+          'replace-remove-element-template': { label: 'Task', action() {} }
+        })
+      });
+
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const entries = openReplace(task);
+
+      // then it is described as the element's plain type, not left blank
+      expect(entries['replace-remove-element-template'].description).to.eql(ELEMENT_DESCRIPTIONS['task']);
+    }
+  ));
+
 });
 
 


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6037
Found by https://github.com/camunda/camunda-modeler/pull/6055#issuecomment-5095405662 

Fixes the missing description on the plain-type entry (e.g. "Service task") in the replace menu of a templated element.

That entry — the "unlink/remove template" option — is added by create-append with a single generic id (replace-remove-element-template) that carries no element type. The description provider keys descriptions off the entry id, so this one fell through and rendered blank.

Fix: Special-case that entry: resolve its description from the element's matching replace option, reusing the canonical replace-with-* action id → so it stays in sync with the normal entries.


https://github.com/user-attachments/assets/83a9c93e-6f2a-4889-bc1c-488df0c9e18c



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
