### PR TITLE
feat: group element templates and linked resources into a Reusable Assets tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
-* `FEAT`: group element templates and linked resources into a Reusable Assets tab ([#490](https://github.com/camunda/camunda-bpmn-js/issues/490))
+* `FEAT`: group popup menu elements into tabs ([#490](https://github.com/camunda/camunda-bpmn-js/issues/490))
+* `FEAT`: tag elements visually inside a group via `categoryValueRef` ([bpmn-io/bpmn-js#2469](https://github.com/bpmn-io/bpmn-js/pull/2469))
+* `FEAT`: eagerly create category value when creating or updating a group ([bpmn-io/bpmn-js#2469](https://github.com/bpmn-io/bpmn-js/pull/2469))
+* `FIX`: do not copy message flows without participants ([bpmn-io/bpmn-js#1902](https://github.com/bpmn-io/bpmn-js/issues/1902), [bpmn-io/bpmn-js#2475](https://github.com/bpmn-io/bpmn-js/pull/2475))
+* `FIX`: ignore labels in `laneRef` updates ([bpmn-io/bpmn-js#2469](https://github.com/bpmn-io/bpmn-js/pull/2469))
+* `FIX`: do not copy message flows without participants ([bpmn-io/bpmn-js#1902](https://github.com/bpmn-io/bpmn-js/issues/1902), [bpmn-io/bpmn-js#2475](https://github.com/bpmn-io/bpmn-js/pull/2475))
+* `DEPS`: update to `diagram-js@15.24.0`
+* `DEPS`: update to `bpmn-js@18.24.0`
 
 ## 5.30.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [camunda-bpmn-js](https://github.com/camunda/camunda-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: group element templates and linked resources into a Reusable Assets tab ([#490](https://github.com/camunda/camunda-bpmn-js/issues/490))
+
 ## 5.30.2
 
 * `FIX`: prevent clipped strokes in exported diagrams ([bpmn-js#2476](https://github.com/bpmn-io/bpmn-js/pull/2476))

--- a/lib/base/features/create-append-tabs/CreateAppendTabsProvider.js
+++ b/lib/base/features/create-append-tabs/CreateAppendTabsProvider.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import inherits from 'inherits-browser';
+
+import { REUSABLE_ASSETS_TAB, orderReusableEntries } from './tabs';
+
+// run after the groups provider (900) built the category tree and after the
+// descriptions / external-resources providers (500) filled it, so the
+// assembled Templates category is there to lift into the tab
+const LOWER_PRIORITY = 400;
+
+/**
+ * Splits the create/append/replace menu across two tabs: the BPMN element
+ * categories stay where they are (no tab → default tab), while element
+ * templates and linked resources move into a Reusable Assets tab.
+ */
+function TabsProvider(popupMenu, menuId, idPrefix) {
+  this._idPrefix = idPrefix;
+
+  popupMenu.registerProvider(menuId, LOWER_PRIORITY, this);
+}
+
+TabsProvider.prototype.getPopupMenuEntries = function() {
+  const idPrefix = this._idPrefix;
+
+  return (entries) => toTabs(entries, idPrefix);
+};
+
+function toTabs(entries, idPrefix) {
+  const templatesCategoryId = `${ idPrefix }-templates`,
+        templatePrefix = `${ idPrefix }.template-`;
+
+  const entriesWithTabs = {};
+
+  let hasReusableAssets = false;
+
+  for (const [ id, entry ] of Object.entries(entries)) {
+
+    // create/append: unwrap the Templates drill-in category, lifting element
+    // templates and linked resources flat into the tab
+    if (id === templatesCategoryId && entry.entries) {
+      for (const [ childId, childEntry ] of Object.entries(entry.entries)) {
+        entriesWithTabs[childId] = assignToReusableAssetsTab(childId, childEntry, templatePrefix);
+      }
+
+      hasReusableAssets = true;
+
+      continue;
+    }
+
+    // replace has no category tree; template and resource entries sit flat
+    if (id.startsWith(templatePrefix) || id.startsWith('resources-')) {
+      entriesWithTabs[id] = assignToReusableAssetsTab(id, entry, templatePrefix);
+
+      hasReusableAssets = true;
+
+      continue;
+    }
+
+    entriesWithTabs[id] = entry;
+  }
+
+  // no reusable assets in this menu — leave it single-tabbed
+  if (!hasReusableAssets) {
+    return entries;
+  }
+
+  return orderReusableEntries(entriesWithTabs);
+}
+
+/**
+ * Assign an entry to the Reusable Assets tab, making its template id
+ * searchable — colleagues share assets by id.
+ */
+function assignToReusableAssetsTab(id, entry, templatePrefix) {
+  const templateId = id.startsWith(templatePrefix)
+    ? id.slice(templatePrefix.length)
+    : null;
+
+  return {
+    ...entry,
+    tab: REUSABLE_ASSETS_TAB,
+    search: templateId ? [ ...asArray(entry.search), templateId ] : entry.search
+  };
+}
+
+function asArray(value) {
+  if (!value) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [ value ];
+}
+
+
+export function CreateTabsProvider(popupMenu) {
+  TabsProvider.call(this, popupMenu, 'bpmn-create', 'create');
+}
+
+inherits(CreateTabsProvider, TabsProvider);
+
+CreateTabsProvider.$inject = [ 'popupMenu' ];
+
+
+export function AppendTabsProvider(popupMenu) {
+  TabsProvider.call(this, popupMenu, 'bpmn-append', 'append');
+}
+
+inherits(AppendTabsProvider, TabsProvider);
+
+AppendTabsProvider.$inject = [ 'popupMenu' ];
+
+
+export function ReplaceTabsProvider(popupMenu) {
+  TabsProvider.call(this, popupMenu, 'bpmn-replace', 'replace');
+}
+
+inherits(ReplaceTabsProvider, TabsProvider);
+
+ReplaceTabsProvider.$inject = [ 'popupMenu' ];

--- a/lib/base/features/create-append-tabs/index.js
+++ b/lib/base/features/create-append-tabs/index.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  CreateTabsProvider,
+  AppendTabsProvider,
+  ReplaceTabsProvider
+} from './CreateAppendTabsProvider';
+
+export default {
+  __init__: [ 'createTabsProvider', 'appendTabsProvider', 'replaceTabsProvider' ],
+  createTabsProvider: [ 'type', CreateTabsProvider ],
+  appendTabsProvider: [ 'type', AppendTabsProvider ],
+  replaceTabsProvider: [ 'type', ReplaceTabsProvider ]
+};

--- a/lib/base/features/create-append-tabs/tabs.js
+++ b/lib/base/features/create-append-tabs/tabs.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/**
+ * @typedef { { id: string, label: string, title?: string } } PopupMenuTab
+ */
+
+/**
+ * Default tab for entries without a `tab` property.
+ *
+ * @type {PopupMenuTab}
+ */
+export const BPMN_TAB = {
+  id: 'bpmn',
+  label: 'BPMN'
+};
+
+/**
+ * The tab holding everything reusable: element templates (connectors, catalog
+ * assets, local templates) and linked resources (forms, called processes,
+ * decisions, RPA).
+ *
+ * @type {PopupMenuTab}
+ */
+export const REUSABLE_ASSETS_TAB = {
+  id: 'reusable-assets',
+  label: 'Reusable Assets',
+  title: 'Building blocks you can reuse: element templates and connectors, '
+    + 'CoE-approved catalog assets, and resources shared in your project '
+    + '(forms, called processes, decisions).'
+};
+
+const DEFAULT_GROUP_ID = 'templates';
+
+const CONNECTORS_GROUP_ID = 'connectors';
+
+const REUSABLE_GROUPS = [
+  'linked-resources', // forms, called processes, decisions, RPA
+  'named-category', // any named template category, e.g. a CoE catalog
+  'generic-templates', // the default Templates group and anything ungrouped
+  'connectors' // the long connectors list, kept last
+];
+
+/**
+ * Whether an entry has been assigned to the Reusable Assets tab.
+ *
+ * @param {Object} entry
+ *
+ * @return {boolean}
+ */
+export function isReusableAsset(entry) {
+  return Boolean(entry.tab && entry.tab.id === REUSABLE_ASSETS_TAB.id);
+}
+
+/**
+ * Order the Reusable Assets tab's groups per REUSABLE_GROUPS, so a curated
+ * catalog is not buried under the connectors. First-seen order is preserved
+ * within each group; `groupEntries` then renders the headers in this order.
+ *
+ * Entries outside the tab keep their position ahead of it.
+ *
+ * @param {Object} entries
+ *
+ * @return {Object}
+ */
+export function orderReusableEntries(entries) {
+  const rest = {};
+  const reusable = [];
+
+  for (const [ id, entry ] of Object.entries(entries)) {
+    if (isReusableAsset(entry)) {
+      reusable.push([ id, entry ]);
+    } else {
+      rest[id] = entry;
+    }
+  }
+
+  if (!reusable.length) {
+    return entries;
+  }
+
+  const ordered = {};
+
+  for (const group of REUSABLE_GROUPS) {
+    for (const [ id, entry ] of reusable) {
+      if (groupOf(id, entry) === group) {
+        ordered[id] = entry;
+      }
+    }
+  }
+
+  return { ...rest, ...ordered };
+}
+
+/**
+ * Classify a reusable entry into one of the `REUSABLE_GROUPS`.
+ *
+ * @param {string} id
+ * @param {Object} entry
+ *
+ * @return {'linked-resources'|'connectors'|'generic-templates'|'named-category'}
+ */
+function groupOf(id, entry) {
+  if (id.startsWith('resources-')) {
+    return 'linked-resources';
+  }
+
+  const groupId = entry.group && (entry.group.id || entry.group);
+
+  if (groupId === CONNECTORS_GROUP_ID) {
+    return 'connectors';
+  }
+
+  if (!groupId || groupId === DEFAULT_GROUP_ID) {
+    return 'generic-templates';
+  }
+
+  return 'named-category';
+}

--- a/lib/camunda-cloud/Modeler.js
+++ b/lib/camunda-cloud/Modeler.js
@@ -41,6 +41,8 @@ import {
 import camundaDetailsPopupMenuModule from './features/popup-menu';
 import elementDescriptionsModule from '../base/features/element-descriptions';
 import createAppendGroupsModule from '../base/features/create-append-groups';
+import createAppendTabsModule from '../base/features/create-append-tabs';
+import { BPMN_TAB } from '../base/features/create-append-tabs/tabs';
 import { DefaultHandlersModule, ResourcesModule } from './features/external-resources';
 
 /**
@@ -57,6 +59,10 @@ export default function Modeler(options = {}) {
     moddleExtensions: {
       ...commonModdleExtensions,
       ...options.moddleExtensions
+    },
+    popupMenu: {
+      defaultTab: BPMN_TAB,
+      ...options.popupMenu
     },
     propertiesPanel: {
       tooltip: ZeebeTooltipProvider,
@@ -109,6 +115,7 @@ Modeler.prototype._camundaCloudModules = [
   camundaDetailsPopupMenuModule,
   elementDescriptionsModule,
   createAppendGroupsModule,
+  createAppendTabsModule,
   DefaultHandlersModule,
   ResourcesModule
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "bpmn-js-native-copy-paste": "^0.3.0",
         "camunda-bpmn-js-behaviors": "^1.18.0",
         "camunda-bpmn-moddle": "^7.0.1",
-        "diagram-js": "^15.23.2",
+        "diagram-js": "^15.24.0",
         "diagram-js-grid": "^2.0.1",
         "diagram-js-minimap": "^5.4.0",
         "diagram-js-origin": "^1.4.0",
@@ -4252,9 +4252,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.23.2",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.2.tgz",
-      "integrity": "sha512-J/CSCKSq62z7aYr643sf+IBiBv3oaJVJc0PivNi09Wdnd/aUOGpIl8PC0HrJn8sLC/lVNtd80MyscbSg2xDZmA==",
+      "version": "15.24.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.24.0.tgz",
+      "integrity": "sha512-RVSeGHVNAWQHM7reWAP0geb245GMVPMeDlsYsilNUrQwR/t+rp8ov0agZArCfV7hUaj8VqIQCMROo50L5MLbbg==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@bpmn-io/properties-panel": "^3.48.0",
         "@bpmn-io/variable-resolver": "^3.3.0",
         "@camunda/example-data-properties-provider": "^1.5.0",
-        "bpmn-js": "^18.22.1",
+        "bpmn-js": "^18.24.0",
         "bpmn-js-color-picker": "^0.7.2",
         "bpmn-js-copy-as-image": "^0.4.1",
         "bpmn-js-create-append-anything": "^2.0.0",
@@ -3141,13 +3141,13 @@
       }
     },
     "node_modules/bpmn-js": {
-      "version": "18.22.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.22.1.tgz",
-      "integrity": "sha512-rO2WTTHGtnCejd4QwzIAXhy0cdSWzM1tU+SSd0WQCpmO5Xq/YsEpNKU+oOD+piboEi0P98RZbQ98JrjyKb+NZg==",
+      "version": "18.24.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.24.0.tgz",
+      "integrity": "sha512-NJ0MgA6QaU0Zxyx+aZbiFlKVNoEKOQ4jCY2EIkddgauB+urIYtLdeSd4UaChG3NiGdrxpefUiK95IVTI9dRDWA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.23.2",
+        "diagram-js": "^15.24.0",
         "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@bpmn-io/properties-panel": "^3.48.0",
     "@bpmn-io/variable-resolver": "^3.3.0",
     "@camunda/example-data-properties-provider": "^1.5.0",
-    "bpmn-js": "^18.22.1",
+    "bpmn-js": "^18.24.0",
     "bpmn-js-color-picker": "^0.7.2",
     "bpmn-js-copy-as-image": "^0.4.1",
     "bpmn-js-create-append-anything": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bpmn-js-native-copy-paste": "^0.3.0",
     "camunda-bpmn-js-behaviors": "^1.18.0",
     "camunda-bpmn-moddle": "^7.0.1",
-    "diagram-js": "^15.23.2",
+    "diagram-js": "^15.24.0",
     "diagram-js-grid": "^2.0.1",
     "diagram-js-minimap": "^5.4.0",
     "diagram-js-origin": "^1.4.0",

--- a/test/camunda-cloud/ModelerSpec.js
+++ b/test/camunda-cloud/ModelerSpec.js
@@ -22,6 +22,7 @@ import diagramXml from './ModelerSpec.simple.bpmn';
 
 import simpleXml from 'test/fixtures/simple.bpmn';
 
+import diagramJSCSS from 'diagram-js/assets/diagram-js.css';
 import propertiesPanelCSS from '@bpmn-io/properties-panel/dist/assets/properties-panel.css';
 import elementTemplatesCSS from 'bpmn-js-element-templates/dist/assets/element-templates.css';
 import colorPickerCSS from 'bpmn-js-color-picker/colors/color-picker.css';
@@ -34,6 +35,13 @@ import templates from './element-templates.json';
 import resources from './resources.json';
 
 var singleStart = window.__env__ && window.__env__.SINGLE_START === 'camunda-cloud-modeler';
+
+// load diagram-js' own stylesheet rather than relying on the copies bundled
+// into dependencies' dist output, so linked diagram-js changes are visible here
+insertCSS(
+  'diagram-js.css',
+  diagramJSCSS
+);
 
 insertCSS(
   'properties-panel.css',

--- a/test/camunda-cloud/features/create-append-tabs/CreateAppendTabsSpec.js
+++ b/test/camunda-cloud/features/create-append-tabs/CreateAppendTabsSpec.js
@@ -1,0 +1,267 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+
+import {
+  act,
+  waitFor
+} from '@testing-library/preact';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  find,
+  map
+} from 'min-dash';
+
+import {
+  bootstrapModeler,
+  getBpmnJS,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import contextPadModule from 'diagram-js/lib/features/context-pad';
+import paletteModule from 'diagram-js/lib/features/palette';
+import editorActionsModule from 'bpmn-js/lib/features/editor-actions';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import popupMenuModule from 'bpmn-js/lib/features/popup-menu';
+
+import {
+  CreateAppendAnythingModule as createAppendAnythingModule
+} from 'bpmn-js-create-append-anything';
+
+import createAppendGroupsModule from 'lib/base/features/create-append-groups';
+
+import createAppendTabsModule from 'lib/base/features/create-append-tabs';
+
+import {
+  BPMN_TAB,
+  REUSABLE_ASSETS_TAB
+} from 'lib/base/features/create-append-tabs/tabs';
+
+import diagramXML from '../element-descriptions/ElementDescriptions.bpmn';
+
+
+const modules = [
+  coreModule,
+  contextPadModule,
+  paletteModule,
+  editorActionsModule,
+  modelingModule,
+  popupMenuModule,
+  createAppendAnythingModule,
+  createAppendGroupsModule,
+  createAppendTabsModule
+];
+
+
+describe('camunda-cloud/features/create-append-tabs', function() {
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules,
+    popupMenu: {
+      defaultTab: BPMN_TAB
+    }
+  }));
+
+
+  describe('create', function() {
+
+    it('should render a BPMN and a Reusable Assets tab', inject(function(canvas) {
+
+      // given
+      contribute('bpmn-create', { 'create.template-foo': template() });
+
+      // when
+      openMenu(canvas.getRootElement(), 'bpmn-create');
+
+      // then
+      expect(tabLabels()).to.eql([ BPMN_TAB.label, REUSABLE_ASSETS_TAB.label ]);
+    }));
+
+
+    it('should keep reusable assets out of the BPMN tab', inject(function(canvas) {
+
+      // given
+      contribute('bpmn-create', { 'create.template-foo': template() });
+
+      // when
+      openMenu(canvas.getRootElement(), 'bpmn-create');
+
+      // then
+      expect(entryIds()).not.to.include('create.template-foo');
+    }));
+
+
+    it('should move reusable assets into the Reusable Assets tab', inject(async function(canvas) {
+
+      // given
+      contribute('bpmn-create', {
+        'create.template-foo': template(),
+        'resources-create-rpa-0': resource()
+      });
+
+      openMenu(canvas.getRootElement(), 'bpmn-create');
+
+      // when
+      await selectTab(REUSABLE_ASSETS_TAB.label);
+
+      // then
+      await waitFor(function() {
+        expect(entryIds()).to.include.members([ 'create.template-foo', 'resources-create-rpa-0' ]);
+      });
+    }));
+
+
+    it('should order groups as resources, categories, templates, connectors', inject(async function(canvas) {
+
+      // given
+      contribute('bpmn-create', {
+        'create.template-connector': template({ id: 'connectors', name: 'Connectors' }),
+        'create.template-plain': template({ id: 'templates', name: 'Templates' }),
+        'create.template-catalog': template({ id: 'catalog', name: 'Catalog' }),
+        'resources-create-rpa-0': resource()
+      });
+
+      openMenu(canvas.getRootElement(), 'bpmn-create');
+
+      // when
+      await selectTab(REUSABLE_ASSETS_TAB.label);
+
+      // then
+      await waitFor(function() {
+        expect(groupIds()).to.eql([ 'rpa', 'catalog', 'templates', 'connectors' ]);
+      });
+    }));
+
+
+    it('should not render tabs without reusable assets', inject(function(canvas) {
+
+      // when
+      openMenu(canvas.getRootElement(), 'bpmn-create');
+
+      // then
+      expect(tabLabels()).to.be.empty;
+    }));
+
+
+    it('should find a reusable asset by its template id', inject(async function(canvas) {
+
+      // given
+      contribute('bpmn-create', { 'create.template-xyzzy': template() });
+
+      openMenu(canvas.getRootElement(), 'bpmn-create');
+
+      // when
+      await triggerSearch('xyzzy');
+
+      // then
+      await waitFor(function() {
+        expect(entryIds()).to.include('create.template-xyzzy');
+      });
+    }));
+
+  });
+
+
+  describe('replace', function() {
+
+    it('should move reusable assets into the Reusable Assets tab', inject(async function(elementRegistry) {
+
+      // given
+      contribute('bpmn-replace', { 'replace.template-foo': template() });
+
+      openMenu(elementRegistry.get('Task_1'), 'bpmn-replace');
+
+      // when
+      await selectTab(REUSABLE_ASSETS_TAB.label);
+
+      // then
+      await waitFor(function() {
+        expect(entryIds()).to.include('replace.template-foo');
+      });
+    }));
+
+  });
+
+});
+
+
+// helpers /////////////
+
+function template(group) {
+  return {
+    label: 'Template',
+    action() {},
+    ...(group && { group })
+  };
+}
+
+function resource() {
+  return {
+    label: 'Resource',
+    action() {},
+    group: { id: 'rpa', name: 'RPA' }
+  };
+}
+
+function contribute(menuId, entries) {
+  getBpmnJS().invoke(function(popupMenu) {
+    popupMenu.registerProvider(menuId, 950, {
+      getPopupMenuEntries: () => (current) => ({ ...current, ...entries })
+    });
+  });
+}
+
+function openMenu(element, menuId) {
+  getBpmnJS().invoke(function(popupMenu) {
+    popupMenu.open(element, menuId, { x: 100, y: 100 }, { search: true });
+  });
+}
+
+function container() {
+  return getBpmnJS().invoke(function(popupMenu) {
+    return popupMenu._current.container;
+  });
+}
+
+function tabLabels() {
+  return map(domQueryAll('.djs-popup-tab', container()), (tab) => tab.textContent.trim());
+}
+
+function groupIds() {
+  return map(domQueryAll('.djs-popup-group', container()), (group) => group.getAttribute('data-group'));
+}
+
+function entryIds() {
+  return map(domQueryAll('.entry', container()), (entry) => entry.getAttribute('data-id'));
+}
+
+async function selectTab(label) {
+  await act(async () => {});
+
+  const tab = find(domQueryAll('.djs-popup-tab', container()), (tab) => tab.textContent.trim() === label);
+
+  await act(() => tab.click());
+}
+
+function triggerSearch(term) {
+  const input = domQuery('.djs-popup-search input', container());
+
+  return act(() => {
+    input.value = term;
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true }));
+  });
+}


### PR DESCRIPTION
### Proposed Changes

Splits the create/append/replace menus into a **BPMN** tab and a **Reusable Assets** tab.

* the `Templates` category is unwrapped and its members lifted into the tab, each keeping its `group` so headers still render
* linked resources — forms, called processes, decisions, RPA — join them
* everything else stays untagged and falls through to the BPMN tab, so a downstream provider's entries keep working without being tab-aware
* template ids become searchable

Scoped to `bpmn-create` / `bpmn-append` / `bpmn-replace`; the element template chooser stays untabbed. Cloud only — the Platform modeler wires the same grouping module, so extending it there is a deliberate follow-up.

The cloud demo now loads diagram-js' own stylesheet. It previously took popup styling from dependencies' prebuilt `dist`, so a linked diagram-js' CSS changes were invisible.

The tab strip comes from https://github.com/bpmn-io/diagram-js/pull/1096, released in diagram-js 15.24.0. `diagram-js` is bumped to `^15.24.0` here — below that the entries are still tagged correctly but no strip renders, so the bump is what makes the feature visible.

Closes https://github.com/camunda/camunda-bpmn-js/issues/490
Related to https://github.com/camunda/product-hub/issues/3481

<img width="720" height="806" alt="Kapture 2026-08-07 at 12 38 51" src="https://github.com/user-attachments/assets/c89c8ca2-6217-4b1c-823b-d36926c5a685" />

### Steps to try out

```
npx @bpmn-io/sr camunda/camunda-bpmn-js#feat-reusable-assets-tab -l bpmn-io/diagram-js#feat-popup-menu-tabs
```

Select the task carrying a template, then `...` in the context pad.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

