### PR TITLE
fix: enable element template chooser for Camunda 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1602,7 +1602,7 @@ This release reverts the breaking changes introduced via [`bpmn-js-element-templ
 
 ### Breaking Changes
 
-* `element-template-chooser` is now provided by default. To disable this, please use the `elementTemplatesChooser` option and set it to `false`.
+* `element-template-chooser` is now provided by default. To disable this, please use the `elementTemplateChooser` option and set it to `false`.
 * No longer ensures interoperability with `bpmn-js-connectors-extension`. This release replaces the connectors extension.
 
 ## 1.5.0

--- a/lib/camunda-platform/Modeler.js
+++ b/lib/camunda-platform/Modeler.js
@@ -30,6 +30,7 @@ import {
 import { commonModdleExtensions } from './util/commonModules';
 
 import colorPickerModule from 'bpmn-js-color-picker';
+import elementTemplateChooserModule from '@bpmn-io/element-template-chooser';
 
 import {
   CreateAppendAnythingModule as createAppendAnythingModule,
@@ -60,10 +61,20 @@ export default function Modeler(options = {}) {
     }
   };
 
+  this._addElementTemplateChooserModule(options);
+
   BaseModeler.call(this, options);
 }
 
 inherits(Modeler, BaseModeler);
+
+Modeler.prototype._addElementTemplateChooserModule = function(options) {
+  const { elementTemplateChooser } = options;
+
+  if (elementTemplateChooser !== false) {
+    this._modules = [ ...this._modules, elementTemplateChooserModule ];
+  }
+};
 
 Modeler.prototype._camundaPlatformModules = [
   behaviorsModule,

--- a/test/camunda-cloud/ModelerSpec.js
+++ b/test/camunda-cloud/ModelerSpec.js
@@ -322,9 +322,7 @@ describe('<CamundaCloudModeler>', function() {
   describe('element template chooser', function() {
 
     const options = {
-      elementTemplatesChooser: {
-        enabled: false
-      }
+      elementTemplateChooser: false
     };
 
     it('should inject element-template-chooser', function() {
@@ -341,10 +339,10 @@ describe('<CamundaCloudModeler>', function() {
 
     it('should not inject element-template-chooser', function() {
 
-      createModeler(simpleXml, [], options).then(function(result) {
+      return createModeler(simpleXml, [], options).then(function(result) {
         let modeler = result.modeler;
 
-        expect(modeler.get.bind(this, 'elementTemplateChooser')).to.throw();
+        expect(modeler.get.bind(modeler, 'elementTemplateChooser')).to.throw();
       });
 
 

--- a/test/camunda-platform/ModelerSpec.js
+++ b/test/camunda-platform/ModelerSpec.js
@@ -24,8 +24,6 @@ import colorPickerCSS from 'bpmn-js-color-picker/colors/color-picker.css';
 
 import popupMenuCSS from '../../styles/popup-menu.css';
 
-import ElementTemplateChooserModule from '@bpmn-io/element-template-chooser';
-
 import elementTemplates from './element-templates.json';
 
 var singleStart = window.__env__ && window.__env__.SINGLE_START === 'camunda-platform-modeler';
@@ -110,7 +108,7 @@ describe('<CamundaPlatformModeler>', function() {
     container.appendChild(propertiesContainer);
   });
 
-  function createModeler(xml) {
+  function createModeler(xml, options = {}) {
 
     clearBpmnJS();
 
@@ -119,9 +117,7 @@ describe('<CamundaPlatformModeler>', function() {
       propertiesPanel: {
         parent: propertiesContainer
       },
-      additionalModules: [
-        ElementTemplateChooserModule
-      ]
+      ...options
     });
 
     singleStart && modeler.on('commandStack.changed', debounce(function() {
@@ -211,6 +207,40 @@ describe('<CamundaPlatformModeler>', function() {
 
       // then
       expect(modeler.get('variableResolver')).to.exist;
+    });
+
+  });
+
+
+  describe('element template chooser', function() {
+
+    it('should inject element-template-chooser', function() {
+
+      // when
+      return createModeler(simpleXml).then(function(result) {
+
+        var modeler = result.modeler;
+
+        // then
+        expect(modeler.get('elementTemplateChooser')).to.exist;
+      });
+
+    });
+
+
+    it('should not inject element-template-chooser when disabled', function() {
+
+      // when
+      return createModeler(simpleXml, {
+        elementTemplateChooser: false
+      }).then(function(result) {
+
+        var modeler = result.modeler;
+
+        // then
+        expect(modeler.get.bind(modeler, 'elementTemplateChooser')).to.throw();
+      });
+
     });
 
   });


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/6108

### Proposed Changes

Make element template chooser available in Camunda 7 BPMN diagrams.

<img width="1252" height="887" alt="image" src="https://github.com/user-attachments/assets/fa2f9d61-6e90-4894-9809-a5a08ba994fc" />

### Steps to try

1. `npm run start:platform`
2. In the properties panel, click Select in the Template group.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
